### PR TITLE
Update/documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ Extends support of the SDK to OneView REST API version 1200 (OneView v5.00).
  3. Introduced mixin classes to include the optional features of the resources.
  4. Added below methods for all the resources by introducing a base class for the resource client classes.
     Appropriate exception will be raised, if any of the features are not available for a resource.
-
-    a) create       - Returns created object
-    b) update       - Returns updated object
-    c) delete       - Returns boolean
-    d) get_all      - Returns list of resource data
-    e) get_by       - Returns resource data
-    f) get_by_name  - Returns resource object
-    g) get_by_uri   - Returns resource object
-
+    
+    | Methods             | Returns                                       |
+    | ------------------  | --------------------------------------------- |
+    | create              |   resource object                             |
+    | update              |   resource object                             |
+    | delete              |   boolean                                     |
+    | get_all             |   list of resource data                       |
+    | get_by_name         |   resource object                             |
+    | get_by_uri          |   resource object                             |
+    | get_by              |   resource data                               |
+    
 #### Breaking
   Enhancement made in this version breaks the previous version of the SDK.
   From this version onwards, create/update/get_by_name/get_by_id will return an object of the resource instead of data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Extends support of the SDK to OneView REST API version 1200 (OneView v5.00).
     
 #### Breaking
   Enhancement made in this version breaks the previous version of the SDK.
-  From this version onwards, create/update/get_by_name/get_by_id will return an object of the resource instead of data.
+  From this version onwards, create/update/get_by_name/get_by_uri will return an object of the resource instead of data.
 
   E.g.
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Extends support of the SDK to OneView REST API version 1200 (OneView v5.00).
  2. Refactored base classes to make resource data available with the resource object.
     This will help to add more helper methods for the resources and hide data complexity from the user.
  3. Introduced mixin classes to include the optional features of the resources.
+ 4. Added below methods for all the resources by introducing a base class for the resource client classes.
+    Appropriate exception will be raised, if any of the features are not available for a resource.
+
+    a) create       - Returns created object
+    b) update       - Returns updated object
+    c) delete       - Returns boolean
+    d) get_all      - Returns list of resource data
+    e) get_by       - Returns resource data
+    f) get_by_name  - Returns resource object
+    g) get_by_uri   - Returns resource object
 
 #### Breaking
   Enhancement made in this version breaks the previous version of the SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Extends support of the SDK to OneView REST API version 1200 (OneView v5.00).
  4. Added below methods for all the resources by introducing a base class for the resource client classes.
     Appropriate exception will be raised, if any of the features are not available for a resource.
     
-    | Methods             | Returns                                       |
+    | Method              | Returns                                       |
     | ------------------  | --------------------------------------------- |
     | create              |   resource object                             |
     | update              |   resource object                             |

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export ONEVIEWSDK_SESSIONID='123'
 
 
 # Optional
-export ONEVIEWSDK_API_VERSION='300'
+export ONEVIEWSDK_API_VERSION='800'
 export ONEVIEWSDK_AUTH_LOGIN_DOMAIN='authdomain'
 export ONEVIEWSDK_SSL_CERTIFICATE='<path_to_cert.crt_file>'
 export ONEVIEWSDK_PROXY='<proxy_host>:<proxy_port>'
@@ -193,30 +193,28 @@ export ONEVIEWSDK_PROXY='<proxy_host>:<proxy_port>'
 
 ### Setting your OneView version
 
-The OneView Python SDK supports the API endpoints for HPE OneView 2.0, 3.0, 3.10, 4.0 and 4.10.
+The OneView Python SDK supports the API endpoints for HPE OneView 4.10, 4.20 and 5.00.
 
-The current `default` HPE OneView version used by the Python SDK is `3.00`, API `300`.
+The current `default` HPE OneView version used by the Python SDK is `4.10`, API `800`.
 
 To use a different API, you must set the API version on the OneViewClient configuration, either using the JSON configuration:
 
 ```json
-"api_version": 600
+"api_version": 800
 ```
 OR using the Environment variable:
 
 ```bash
-export ONEVIEWSDK_API_VERSION='600'
+export ONEVIEWSDK_API_VERSION='800'
 ```
 
-If this property is not specified, it will fall back to the ```300``` default value.
+If this property is not specified, it will fall back to the ```800``` default value.
 
 The API list is as follows:
 
-- HPE OneView 2.0 API version: `200`
-- HPE OneView 3.0 API version: `300`
-- HPE OneView 3.10 API version: `500`
-- HPE OneView 4.0 API version: `600`
 - HPE OneView 4.10 API version: `800`
+- HPE OneView 4.20 API version: `1000`
+- HPE OneView 5.00 API version: `1200`
 
 ### HPE Synergy Image Streamer
 
@@ -278,7 +276,7 @@ try:
 except HPOneViewException as e:
     print(e.msg)
     if e.oneview_response:
-    	pprint(e.oneview_response)   
+    	pprint(e.oneview_response)
 ```
 
 For compatibility purposes, the Exception args property is defined with the error arguments. For example:

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -274,14 +274,14 @@
 |<sub>/rest/storage-volume-attachments/{attachmentId}/paths</sub>                         | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |<sub>/rest/storage-volume-attachments/{attachmentId)/paths/{id}</sub>                    | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |     **Storage Volume Templates**
-|<sub>/rest/storage-volume-templates</sub>                                                | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates</sub>                                                | POST     | white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/connectable-volume-templates</sub>                   | GET      | heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign:
-|<sub>/rest/storage-volume-templates/reachable-volume-templates</sub>                     | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}</sub>                                           | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}</sub>                                           | PUT      | white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}</sub>                                           | DELETE   | white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}/compatible-systems</sub>                        | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates</sub>                                                | GET      | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates</sub>                                                | POST     | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/connectable-volume-templates</sub>                   | GET      | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign:
+|<sub>/rest/storage-volume-templates/reachable-volume-templates</sub>                     | GET      | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}</sub>                                           | GET      | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}</sub>                                           | PUT      | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}</sub>                                           | DELETE   | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}/compatible-systems</sub>                        | GET      | :white_check_mark: | :white_check_mark: | :white_check_mark:
 |     **Switch Types**
 |<sub>/rest/switch-types</sub>                                                            | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/switch-types/{id}</sub>                                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -18,305 +18,305 @@
 
 ## HPE OneView
 
-| Endpoints                                                                               | Verb     | V500                 | V600                 | V800                 | V1000               | V1200
-| --------------------------------------------------------------------------------------- | -------- | :------------------: | :------------------: | :------------------: | :------------------:| :------------------: |
+| Endpoints                                                                               | Verb     |  V800                 | V1000               | V1200
+| --------------------------------------------------------------------------------------- | -------- |  :------------------: | :------------------:| :------------------: |
 |     **Connection Templates**
-|<sub>/rest/connection-templates</sub>                                                    |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/connection-templates/{id}</sub>                                               |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/connection-templates/{id}</sub>                                               |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates</sub>                                                    |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates/{id}</sub>                                               |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/connection-templates/{id}</sub>                                               |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Enclosure Groups**
-|<sub>/rest/enclosure-groups</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups</sub>                                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}</sub>                                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}</sub>                                                   | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups</sub>                                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups</sub>                                                        | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}</sub>                                                   | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}</sub>                                                   | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}</sub>                                                   | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosure-groups/{id}/script</sub>                                            | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Enclosures**
-|<sub>/rest/enclosures</sub>                                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures</sub>                                                              | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}</sub>                                                         | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}</sub>                                                         | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/configuration</sub>                                           | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/environmentalConfiguration</sub>                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/environmentalConfiguration</sub>                              | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/refreshState</sub>                                            | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/script</sub>                                                  | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/enclosures/{id}/sso</sub>                                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/utilization</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/https/certificaterequest</sub>                                | GET      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/https/certificaterequest</sub>                                | POST     | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/enclosures/{id}/https/certificaterequest</sub>                                | PUT      | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures</sub>                                                              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures</sub>                                                              | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}</sub>                                                         | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}</sub>                                                         | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/configuration</sub>                                           | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/environmentalConfiguration</sub>                              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/environmentalConfiguration</sub>                              | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/refreshState</sub>                                            | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/script</sub>                                                  | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/enclosures/{id}/sso</sub>                                                     | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/utilization</sub>                                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/https/certificaterequest</sub>                                | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/https/certificaterequest</sub>                                | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/enclosures/{id}/https/certificaterequest</sub>                                | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Ethernet Networks**
-|<sub>/rest/ethernet-networks</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks</sub>                                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/bulk</sub>                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PATCH    | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/ethernet-networks/{id}</sub>                                                  | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}/associatedProfiles</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/ethernet-networks/{id}/associatedUplinkGroups</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks</sub>                                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks</sub>                                                       | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/bulk</sub>                                                  | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | PATCH    |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/ethernet-networks/{id}</sub>                                                  | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}/associatedProfiles</sub>                               | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/ethernet-networks/{id}/associatedUplinkGroups</sub>                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **FC Networks**
-|<sub>/rest/fc-networks</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | PATCH    | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks</sub>                                                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks</sub>                                                             | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | PATCH    |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-networks/{id}</sub>                                                        | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **FCoE Networks**
-|<sub>/rest/fcoe-networks</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks</sub>                                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|     **Interconnects**                                                                                                                            |
-|<sub>/rest/interconnects</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}</sub>                                                      | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/configuration</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/pluggableModuleInformation</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/ports</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/ports</sub>                                                | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/ports/{portId:.+}</sub>                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/resetportprotection</sub>                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/statistics</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/statistics/{portName:.+}</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/statistics/{portName:.+}/subport/{subportNum}</sub>        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/update-ports</sub>                                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnects/{id}/nameServers</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks</sub>                                                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks</sub>                                                           | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|     **Interconnects**
+|<sub>/rest/interconnects</sub>                                                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}</sub>                                                      | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}</sub>                                                      | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/configuration</sub>                                        | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/pluggableModuleInformation</sub>                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/ports</sub>                                                | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/ports</sub>                                                | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/ports/{portId:.+}</sub>                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/resetportprotection</sub>                                  | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/statistics</sub>                                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/statistics/{portName:.+}</sub>                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/statistics/{portName:.+}/subport/{subportNum}</sub>        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/update-ports</sub>                                         | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnects/{id}/nameServers</sub>                                          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Interconnect Types**
-|<sub>/rest/interconnect-types</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/interconnect-types/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnect-types</sub>                                                      | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/interconnect-types/{id}</sub>                                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Internal Link Sets**
-|<sub>/rest/internal-link-sets</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
-|<sub>/rest/internal-link-sets/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/internal-link-sets</sub>                                                      | GET      | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/internal-link-sets/{id}</sub>                                                 | GET      | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
 |     **Logical Enclosures**
-|<sub>/rest/logical-enclosures</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures</sub>                                                      | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}</sub>                                                 | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/configuration</sub>                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/support-dumps</sub>                                   | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-enclosures/{id}/updateFromGroup</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures</sub>                                                      | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures</sub>                                                      | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}</sub>                                                 | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/configuration</sub>                                   | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/script</sub>                                          | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/support-dumps</sub>                                   | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-enclosures/{id}/updateFromGroup</sub>                                 | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnect Groups**
-|<sub>/rest/logical-interconnect-groups</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups</sub>                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups</sub>                                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups</sub>                                             | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/defaultSettings</sub>                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | PATCH    |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/logical-interconnect-groups/{id}</sub>                                        | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnect-groups/{id}/settings</sub>                               | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Logical Interconnects**
-|<sub>/rest/logical-interconnects</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | POST     | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | DELETE   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/compliance</sub>                                   | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/ethernetSettings</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/ethernetSettings</sub>                             | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/firmware</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/firmware</sub>                                     | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/forwarding-information-base</sub>                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/forwarding-information-base</sub>                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/forwarding-information-base/{dumpFileName}.{suffix}</sub>| GET   | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x:   |
-|<sub>/rest/logical-interconnects/{id}/internalNetworks</sub>                             | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/internalVlans</sub>                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/qos-aggregated-configuration</sub>                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/qos-aggregated-configuration</sub>                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/settings</sub>                                     | PUT      | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/logical-interconnects/{id}/snmp-configuration</sub>                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/snmp-configuration</sub>                           | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/support-dumps</sub>                                | POST     | :heavy_multiplication_x: | :heavy_multiplication_x:   | :heavy_multiplication_x:  |  :heavy_multiplication_x:  |
-|<sub>/rest/logical-interconnects/{id}/unassignedPortsForPortMonitor</sub>                | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/unassignedUplinkPortsForPortMonitor</sub>          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/configuration</sub>                                | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/port-monitor</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/port-monitor</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/telemetry-configurations/{tcId}</sub>              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/{id}/telemetry-configurations/{tcId}</sub>              | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/logical-interconnects/compliance</sub>                                        | POST     | :heavy_multiplication_x:       |:heavy_multiplication_x:     |:heavy_multiplication_x:     | :heavy_multiplication_x:     | :heavy_multiplication_x:     |
-|<sub>/rest/logical-interconnects/{id}</sub>                                              | PATCH    | :white_check_mark:   |  :heavy_minus_sign:  |  :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/logical-interconnects</sub>                                                   | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/locations/interconnects</sub>                           | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}</sub>                                              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/compliance</sub>                                   | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/ethernetSettings</sub>                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/ethernetSettings</sub>                             | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/firmware</sub>                                     | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/firmware</sub>                                     | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/forwarding-information-base</sub>                  | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/forwarding-information-base</sub>                  | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/forwarding-information-base/{dumpFileName}.{suffix}</sub>| GET   | :heavy_multiplication_x:   | :heavy_multiplication_x:   | :heavy_multiplication_x:   |
+|<sub>/rest/logical-interconnects/{id}/internalNetworks</sub>                             | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/internalVlans</sub>                                | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/qos-aggregated-configuration</sub>                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/qos-aggregated-configuration</sub>                 | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/settings</sub>                                     | PUT      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/logical-interconnects/{id}/snmp-configuration</sub>                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/snmp-configuration</sub>                           | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/support-dumps</sub>                                | POST     | :heavy_multiplication_x:   | :heavy_multiplication_x:  |  :heavy_multiplication_x:  |
+|<sub>/rest/logical-interconnects/{id}/unassignedPortsForPortMonitor</sub>                | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/unassignedUplinkPortsForPortMonitor</sub>          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/configuration</sub>                                | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/port-monitor</sub>                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/port-monitor</sub>                                 | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/telemetry-configurations/{tcId}</sub>              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/{id}/telemetry-configurations/{tcId}</sub>              | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/logical-interconnects/compliance</sub>                                        | POST     |  :heavy_multiplication_x:     | :heavy_multiplication_x:     | :heavy_multiplication_x:     |
+|<sub>/rest/logical-interconnects/{id}</sub>                                              | PATCH    |  :heavy_minus_sign:  |  :white_check_mark:  | :white_check_mark:  |
 |     **Logical Switch Groups**
-|<sub>/rest/logical-switch-groups</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
-|<sub>/rest/logical-switch-groups</sub>                                                   |POST      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
-|<sub>/rest/logical-switch-groups/{id}</sub>                                              |GET       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
-|<sub>/rest/logical-switch-groups/{id}</sub>                                              | PATCH    | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_minus_sign:  |
-|<sub>/rest/logical-switch-groups/{id}</sub>                                              |PUT       | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
-|<sub>/rest/logical-switch-groups/{id}</sub>                                              |DELETE    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/logical-switch-groups</sub>                                                   | GET      |  :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/logical-switch-groups</sub>                                                   |POST      |  :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/logical-switch-groups/{id}</sub>                                              |GET       |  :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/logical-switch-groups/{id}</sub>                                              | PATCH    |  :heavy_minus_sign:  | :heavy_minus_sign:  | :heavy_minus_sign:  |
+|<sub>/rest/logical-switch-groups/{id}</sub>                                              |PUT       |  :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
+|<sub>/rest/logical-switch-groups/{id}</sub>                                              |DELETE    |  :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
 |     **Managed SANs**
-|<sub>/rest/fc-sans/managed-sans</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-sans/managed-sans/{id}</sub>                                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-sans/managed-sans/{id}</sub>                                               | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-sans/managed-sans/{id}/endpoints</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-sans/managed-sans/{id}/endpoints</sub>                                     | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-sans/managed-sans/{id}/issues</sub>                                        | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/fc-sans/managed-sans/WWN+</sub>                                               | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/fc-sans/managed-sans</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-sans/managed-sans/{id}</sub>                                               | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-sans/managed-sans/{id}</sub>                                               | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-sans/managed-sans/{id}/endpoints</sub>                                     | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-sans/managed-sans/{id}/endpoints</sub>                                     | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-sans/managed-sans/{id}/issues</sub>                                        | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/fc-sans/managed-sans/WWN+</sub>                                               | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |     **Network Sets**
-|<sub>/rest/network-sets</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets</sub>                                                            | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/withoutEthernet</sub>                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}/withoutEthernet</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/network-sets/{id}</sub>                                                       | PATCH    | :white_check_mark:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/network-sets</sub>                                                            | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets</sub>                                                            | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/withoutEthernet</sub>                                            | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}/withoutEthernet</sub>                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/network-sets/{id}</sub>                                                       | PATCH    |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |     **OS Deployment Plans**
-|<sub>/rest/os-deployment-plans/</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/os-deployment-plans/{id}</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/os-deployment-plans/</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/os-deployment-plans/{id}</sub>                                                | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Interconnect Types**
-|<sub>/rest/sas-interconnect-types</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-interconnect-types/{id}</sub>                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnect-types</sub>                                                  | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnect-types/{id}</sub>                                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Interconnects**
-|<sub>/rest/sas-interconnects</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-interconnects/{id}</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-interconnects/{id}</sub>                                                  | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-interconnects/{id}/refreshState</sub>                                     | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnects</sub>                                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnects/{id}</sub>                                                  | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnects/{id}</sub>                                                  | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-interconnects/{id}/refreshState</sub>                                     | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Logical Interconnect Groups**
-|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups</sub>                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnect-groups/{id}</sub>                                    | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **SAS Logical Interconnects**
-|<sub>/rest/sas-logical-interconnects</sub>                                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/{id}</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/{id}/firmware</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/{id}/firmware</sub>                                 | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/compliance</sub>                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/{id}/compliance</sub>                               | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/{lsId}/configuration</sub>                          | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/sas-logical-interconnects/{id}/replaceDriveEnclosure</sub>                    | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects</sub>                                               | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/{id}</sub>                                          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/{id}/firmware</sub>                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/{id}/firmware</sub>                                 | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/compliance</sub>                                    | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/{id}/compliance</sub>                               | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/{lsId}/configuration</sub>                          | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/sas-logical-interconnects/{id}/replaceDriveEnclosure</sub>                    | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Server Hardware**
-|<sub>/rest/server-hardware</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/bios</sub>                                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/iloSsoUrl</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/javaRemoteConsoleUrl</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/mpFirmwareVersion</sub>                                  | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/physicalServerHardware</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/powerState</sub>                                         | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/refreshState</sub>                                       | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/remoteConsoleUrl</sub>                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/utilization</sub>                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}                                                          | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/*/firmware                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/firmware                                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/discovery                                                     | POST     | :heavy_minus_sign:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware</sub>                                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}</sub>                                                    | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/bios</sub>                                               | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/environmentalConfiguration</sub>                         | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/iloSsoUrl</sub>                                          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/javaRemoteConsoleUrl</sub>                               | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/mpFirmwareVersion</sub>                                  | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/physicalServerHardware</sub>                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/powerState</sub>                                         | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/refreshState</sub>                                       | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/remoteConsoleUrl</sub>                                   | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/utilization</sub>                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}                                                          | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/*/firmware                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/firmware                                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/discovery                                                     | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Server Hardware Types**
-|<sub>/rest/server-hardware-types</sub>                                                   | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware-types/{id}</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware-types/{id}</sub>                                              | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware-types/{id}</sub>                                              | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware-types</sub>                                                   | GET      |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware-types/{id}</sub>                                              | GET      |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware-types/{id}</sub>                                              | PUT      |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware-types/{id}</sub>                                              | DELETE   |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   |
 |     **Server Profile Templates**
-|<sub>/rest/server-profile-templates</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates</sub>                                                | POST     | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates/{id}</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates/{id}</sub>                                           | PUT      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates/{id}</sub>                                           | DELETE   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates/{id}/new-profile</sub>                               | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates/{id}/transformation</sub>                            | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profile-templates/available-networks</sub>                             | GET      | :heavy_minus_sign:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates</sub>                                                | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates</sub>                                                | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates/{id}</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates/{id}</sub>                                           | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates/{id}</sub>                                           | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates/{id}/new-profile</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates/{id}/transformation</sub>                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profile-templates/available-networks</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Server Profiles**
-|<sub>/rest/server-profiles</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles</sub>                                                         | DELETE   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-networks</sub>                                      | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-servers</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/available-storage-system</sub>                                | GET      | :white_check_mark:   | :heavy_minus_sign:  | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/server-profiles/available-storage-systems</sub>                               | GET      | :white_check_mark:   | :heavy_minus_sign:  | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/server-profiles/available-targets</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/profile-ports</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | PUT      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}</sub>                                                    | PATCH    | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/compliance-preview</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/new-profile-template</sub>                               | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-profiles/{id}/messages</sub>                                           | GET      | :white_check_mark:   | :heavy_minus_sign:  | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/server-profiles/{id}/transformation</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles</sub>                                                         | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/available-networks</sub>                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/available-servers</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/available-storage-system</sub>                                | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/server-profiles/available-storage-systems</sub>                               | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/server-profiles/available-targets</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/profile-ports</sub>                                           | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}</sub>                                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}</sub>                                                    | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}/compliance-preview</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}/new-profile-template</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-profiles/{id}/messages</sub>                                           | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/server-profiles/{id}/transformation</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Storage Pools**
-|<sub>/rest/storage-pools</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-pools</sub>                                                           | POST     | :heavy_minus_sign:   | :heavy_minus_sign:  | :heavy_minus_sign:   | :heavy_minus_sign: | :heavy_minus_sign:
-|<sub>/rest/storage-pools/reachable-storage-pools</sub>                                   | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-pools/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-pools/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark:  | :white_check_mark:   | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-pools/{id}</sub>                                                      | DELETE   | :heavy_minus_sign:   | :heavy_minus_sign:  | :heavy_minus_sign:   | :heavy_minus_sign: | :heavy_minus_sign:
+|<sub>/rest/storage-pools</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-pools</sub>                                                           | POST     | :heavy_minus_sign:   | :heavy_minus_sign: | :heavy_minus_sign:
+|<sub>/rest/storage-pools/reachable-storage-pools</sub>                                   | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-pools/{id}</sub>                                                      | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-pools/{id}</sub>                                                      | PUT      | :white_check_mark:   | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-pools/{id}</sub>                                                      | DELETE   | :heavy_minus_sign:   | :heavy_minus_sign: | :heavy_minus_sign:
 |     **Storage Systems**
-|<sub>/rest/storage-systems</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/host-types</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/{arrayId}/storage-pools</sub>                                 | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/{id}</sub>                                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/{id}/managedPorts</sub>                                       | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/storage-systems/{id}/managedPorts/{portId}</sub>                              | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/storage-systems/{id}/reachable-ports</sub>                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-systems/{id}/templates</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems</sub>                                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/host-types</sub>                                              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/{arrayId}/storage-pools</sub>                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/{id}</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/{id}</sub>                                                    | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/{id}</sub>                                                    | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/{id}/managedPorts</sub>                                       | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/storage-systems/{id}/managedPorts/{portId}</sub>                              | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/storage-systems/{id}/reachable-ports</sub>                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-systems/{id}/templates</sub>                                          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Storage Volume Attachments**
-|<sub>/rest/storage-volume-attachments</sub>                                              | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volume-attachments/{id}</sub>                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volume-attachments/repair</sub>                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volume-attachments/repair</sub>                                       | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volume-attachments/{attachmentId}/paths</sub>                         | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
-|<sub>/rest/storage-volume-attachments/{attachmentId)/paths/{id}</sub>                    | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/storage-volume-attachments</sub>                                              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volume-attachments/{id}</sub>                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volume-attachments/repair</sub>                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volume-attachments/repair</sub>                                       | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volume-attachments/{attachmentId}/paths</sub>                         | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
+|<sub>/rest/storage-volume-attachments/{attachmentId)/paths/{id}</sub>                    | GET      |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |     **Storage Volume Templates**
-|<sub>/rest/storage-volume-templates</sub>                                                | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates</sub>                                                | POST     | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/connectable-volume-templates</sub>                   | GET      | :heavy_minus_sign:   | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign:
-|<sub>/rest/storage-volume-templates/reachable-volume-templates</sub>                     | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}</sub>                                           | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}</sub>                                           | PUT      | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}</sub>                                           | DELETE   | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
-|<sub>/rest/storage-volume-templates/{id}/compatible-systems</sub>                        | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates</sub>                                                | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates</sub>                                                | POST     | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/connectable-volume-templates</sub>                   | GET      | heavy_minus_sign: | :heavy_minus_sign: | :heavy_minus_sign:
+|<sub>/rest/storage-volume-templates/reachable-volume-templates</sub>                     | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}</sub>                                           | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}</sub>                                           | PUT      | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}</sub>                                           | DELETE   | white_check_mark: | :white_check_mark: | :white_check_mark:
+|<sub>/rest/storage-volume-templates/{id}/compatible-systems</sub>                        | GET      | white_check_mark: | :white_check_mark: | :white_check_mark:
 |     **Switch Types**
-|<sub>/rest/switch-types</sub>                                                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/switch-types/{id}</sub>                                                       | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switch-types</sub>                                                            | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/switch-types/{id}</sub>                                                       | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Uplink Sets**
-|<sub>/rest/uplink-sets</sub>                                                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/uplink-sets/{id}</sub>                                                        | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets</sub>                                                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets</sub>                                                             | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/uplink-sets/{id}</sub>                                                        | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Volumes**
-|<sub>/rest/storage-volumes</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/attachable-volumes</sub>                                      | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/from-existing</sub>                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/from-snapshot</sub>                                           | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/repair</sub>                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/repair</sub>                                                  | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}</sub>                                                    | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}</sub>                                                    | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}</sub>                                                    | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}/snapshots</sub>                                          | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}/snapshots</sub>                                          | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}/snapshots/{snapshotId}</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/storage-volumes/{id}/snapshots/{snapshotId}</sub>                             | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes</sub>                                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/attachable-volumes</sub>                                      | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/from-existing</sub>                                           | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/from-snapshot</sub>                                           | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/repair</sub>                                                  | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/repair</sub>                                                  | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}</sub>                                                    | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}</sub>                                                    | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}/snapshots</sub>                                          | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}/snapshots</sub>                                          | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}/snapshots/{snapshotId}</sub>                             | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/storage-volumes/{id}/snapshots/{snapshotId}</sub>                             | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 
 
 ## HPE Synergy Image Streamer
 
-| Endpoints                                                                       | Verb             | V500                 | V600                 | V800                 | V1000                 | V1020
-| ------------------------------------------------------------------------------  | ---------------- | :------------------: | :------------------: | :------------------: | :------------------:  | :------------------:  |
-|     **Deployment Plans**                                                                                         |
-|<sub> /rest/deployment-plans </sub>                                              | POST             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-|<sub> /rest/deployment-plans </sub>                                              | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id} </sub>                                         | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id} </sub>                                         | PUT              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id} </sub>                                         | DELETE           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id}/usedby </sub>                                  | GET              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-|<sub> /rest/deployment-plans/{id}/osdp </sub>                                    | GET              | :heavy_minus_sign: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Endpoints                                                                       | Verb             | V800                 | V1000                 | V1020
+| ------------------------------------------------------------------------------  | ---------------- | :------------------: | :------------------:  | :------------------:  |
+|     **Deployment Plans**
+|<sub> /rest/deployment-plans </sub>                                              | POST             |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans </sub>                                              | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id} </sub>                                         | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id} </sub>                                         | PUT              |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id} </sub>                                         | DELETE           |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id}/usedby </sub>                                  | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/deployment-plans/{id}/osdp </sub>                                    | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 
 
 class connection(object):
-    def __init__(self, applianceIp, api_version=300, sslBundle=False, timeout=None):
+    def __init__(self, applianceIp, api_version=800, sslBundle=False, timeout=None):
         self._session = None
         self._host = applianceIp
         self._cred = None

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -112,7 +112,7 @@ ONEVIEW_CLIENT_INVALID_PROXY = 'Invalid Proxy format'
 
 
 class OneViewClient(object):
-    DEFAULT_API_VERSION = 300
+    DEFAULT_API_VERSION = 800
 
     def __init__(self, config):
         self.__connection = connection(config["ip"], config.get('api_version', self.DEFAULT_API_VERSION), config.get('ssl_certificate', False),
@@ -350,9 +350,7 @@ class OneViewClient(object):
         Returns:
             FcoeNetworks:
         """
-        if not self.__fcoe_networks:
-            self.__fcoe_networks = FcoeNetworks(self.__connection)
-        return self.__fcoe_networks
+        return FcoeNetworks(self.__connection)
 
     @property
     def ethernet_networks(self):
@@ -420,9 +418,7 @@ class OneViewClient(object):
         Returns:
             NetworkSets:
         """
-        if not self.__network_sets:
-            self.__network_sets = NetworkSets(self.__connection)
-        return self.__network_sets
+        return NetworkSets(self.__connection)
 
     @property
     def server_hardware(self):
@@ -432,9 +428,7 @@ class OneViewClient(object):
         Returns:
             ServerHardware:
         """
-        if not self.__server_hardware:
-            self.__server_hardware = ServerHardware(self.__connection)
-        return self.__server_hardware
+        return ServerHardware(self.__connection)
 
     @property
     def server_hardware_types(self):
@@ -444,10 +438,7 @@ class OneViewClient(object):
         Returns:
             ServerHardwareTypes:
         """
-        if not self.__server_hardware_types:
-            self.__server_hardware_types = ServerHardwareTypes(
-                self.__connection)
-        return self.__server_hardware_types
+        return ServerHardwareTypes(self.__connection)
 
     @property
     def id_pools_vsn_ranges(self):
@@ -553,9 +544,7 @@ class OneViewClient(object):
         Returns:
             SwitchTypes:
         """
-        if not self.__switch_types:
-            self.__switch_types = SwitchTypes(self.__connection)
-        return self.__switch_types
+        return SwitchTypes(self.__connection)
 
     @property
     def logical_switch_groups(self):
@@ -599,9 +588,7 @@ class OneViewClient(object):
         Returns:
             EnclosureGroups:
         """
-        if not self.__enclosure_groups:
-            self.__enclosure_groups = EnclosureGroups(self.__connection)
-        return self.__enclosure_groups
+        return EnclosureGroups(self.__connection)
 
     @property
     def enclosures(self):
@@ -621,9 +608,7 @@ class OneViewClient(object):
         Returns:
             LogicalEnclosures:
         """
-        if not self.__logical_enclosures:
-            self.__logical_enclosures = LogicalEnclosures(self.__connection)
-        return self.__logical_enclosures
+        return LogicalEnclosures(self.__connection)
 
     @property
     def metric_streaming(self):
@@ -645,9 +630,7 @@ class OneViewClient(object):
         Returns:
             Interconnects:
         """
-        if not self.__interconnects:
-            self.__interconnects = Interconnects(self.__connection)
-        return self.__interconnects
+        return Interconnects(self.__connection)
 
     @property
     def interconnect_types(self):
@@ -679,9 +662,7 @@ class OneViewClient(object):
         Returns:
             SasInterconnectTypes:
         """
-        if not self.__sas_interconnect_types:
-            self.__sas_interconnect_types = SasInterconnectTypes(self.__connection)
-        return self.__sas_interconnect_types
+        return SasInterconnectTypes(self.__connection)
 
     @property
     def internal_link_sets(self):
@@ -691,9 +672,7 @@ class OneViewClient(object):
         Returns:
             InternalLinkSets:
         """
-        if not self.__internal_link_sets:
-            self.__internal_link_sets = InternalLinkSets(self.__connection)
-        return self.__internal_link_sets
+        return InternalLinkSets(self.__connection)
 
     @property
     def logical_interconnect_groups(self):
@@ -703,10 +682,7 @@ class OneViewClient(object):
         Returns:
             LogicalInterconnectGroups:
         """
-        if not self.__logical_interconnect_groups:
-            self.__logical_interconnect_groups = LogicalInterconnectGroups(
-                self.__connection)
-        return self.__logical_interconnect_groups
+        return LogicalInterconnectGroups(self.__connection)
 
     @property
     def logical_interconnects(self):
@@ -726,9 +702,7 @@ class OneViewClient(object):
         Returns:
             SasLogicalInterconnects:
         """
-        if not self.__sas_logical_interconnects:
-            self.__sas_logical_interconnects = SasLogicalInterconnects(self.__connection)
-        return self.__sas_logical_interconnects
+        return SasLogicalInterconnects(self.__connection)
 
     @property
     def logical_downlinks(self):
@@ -831,9 +805,7 @@ class OneViewClient(object):
         Returns:
             StorageSystems:
         """
-        if not self.__storage_systems:
-            self.__storage_systems = StorageSystems(self.__connection)
-        return self.__storage_systems
+        return StorageSystems(self.__connection)
 
     @property
     def storage_pools(self):
@@ -843,9 +815,7 @@ class OneViewClient(object):
         Returns:
             StoragePools:
         """
-        if not self.__storage_pools:
-            self.__storage_pools = StoragePools(self.__connection)
-        return self.__storage_pools
+        return StoragePools(self.__connection)
 
     @property
     def storage_volume_templates(self):
@@ -855,9 +825,7 @@ class OneViewClient(object):
         Returns:
             StorageVolumeTemplates:
         """
-        if not self.__storage_volume_templates:
-            self.__storage_volume_templates = StorageVolumeTemplates(self.__connection)
-        return self.__storage_volume_templates
+        return StorageVolumeTemplates(self.__connection)
 
     @property
     def storage_volume_attachments(self):
@@ -867,9 +835,7 @@ class OneViewClient(object):
         Returns:
             StorageVolumeAttachments:
         """
-        if not self.__storage_volume_attachments:
-            self.__storage_volume_attachments = StorageVolumeAttachments(self.__connection)
-        return self.__storage_volume_attachments
+        return StorageVolumeAttachments(self.__connection)
 
     @property
     def firmware_drivers(self):
@@ -913,9 +879,7 @@ class OneViewClient(object):
         Returns:
             Volumes:
         """
-        if not self.__volumes:
-            self.__volumes = Volumes(self.__connection)
-        return self.__volumes
+        return Volumes(self.__connection)
 
     @property
     def sas_logical_jbod_attachments(self):
@@ -937,9 +901,7 @@ class OneViewClient(object):
         Returns:
             ManagedSANs:
         """
-        if not self.__managed_sans:
-            self.__managed_sans = ManagedSANs(self.__connection)
-        return self.__managed_sans
+        return ManagedSANs(self.__connection)
 
     @property
     def migratable_vc_domains(self):
@@ -961,9 +923,7 @@ class OneViewClient(object):
         Returns:
             SasInterconnects:
         """
-        if not self.__sas_interconnects:
-            self.__sas_interconnects = SasInterconnects(self.__connection)
-        return self.__sas_interconnects
+        return SasInterconnects(self.__connection)
 
     @property
     def sas_logical_interconnect_groups(self):
@@ -973,9 +933,7 @@ class OneViewClient(object):
         Returns:
             SasLogicalInterconnectGroups:
         """
-        if not self.__sas_logical_interconnect_groups:
-            self.__sas_logical_interconnect_groups = SasLogicalInterconnectGroups(self.__connection)
-        return self.__sas_logical_interconnect_groups
+        return SasLogicalInterconnectGroups(self.__connection)
 
     @property
     def drive_enclosures(self):

--- a/tests/unit/resources/networking/test_ethernet_networks.py
+++ b/tests/unit/resources/networking/test_ethernet_networks.py
@@ -51,7 +51,7 @@ class EthernetNetworksTest(TestCase):
             "privateNetwork": False
         }
         resource_rest_call = resource.copy()
-        resource_rest_call['type'] = 'ethernet-networkV300'
+        resource_rest_call['type'] = 'ethernet-networkV4'
         mock_create.return_value = {}
 
         self._ethernet_networks.create(resource, timeout=12)
@@ -72,7 +72,7 @@ class EthernetNetworksTest(TestCase):
             }
         }
         resource_rest_call = resource.copy()
-        resource_rest_call['type'] = 'bulk-ethernet-network'
+        resource_rest_call['type'] = 'bulk-ethernet-networkV1'
 
         mock_create.return_value = {}
         mock_get_all.return_value = []

--- a/tests/unit/resources/networking/test_logical_interconnects.py
+++ b/tests/unit/resources/networking/test_logical_interconnects.py
@@ -133,7 +133,7 @@ class LogicalInterconnectsTest(unittest.TestCase):
         }
         settings_rest_call = settings.copy()
         settings_rest_call["type"] = "type"
-        settings_rest_call["ethernetSettings"]["type"] = "EthernetInterconnectSettingsV201"
+        settings_rest_call["ethernetSettings"]["type"] = "EthernetInterconnectSettingsV4"
         self._logical_interconnect.update_settings(settings)
 
         mock_update.assert_called_once_with(settings_rest_call, uri=uri_rest_call, force=False, timeout=-1)
@@ -142,7 +142,7 @@ class LogicalInterconnectsTest(unittest.TestCase):
     def test_update_settings_with_force(self, mock_update):
         self._logical_interconnect.update_settings({}, force=True)
 
-        mock_update.assert_called_once_with({"type": "InterconnectSettingsV201"},
+        mock_update.assert_called_once_with({},
                                             uri="/rest/logical-interconnects/ad28cf21-8b15-4f92-bdcf-51cb2042db32/settings",
                                             force=True, timeout=-1)
 
@@ -155,10 +155,9 @@ class LogicalInterconnectsTest(unittest.TestCase):
         }
         settings_with_default_values = {
             "ethernetSettings": {
-                "type": "EthernetInterconnectSettingsV201",
+                "type": "EthernetInterconnectSettingsV4",
                 "macRefreshInterval": "5"
-            },
-            "type": "InterconnectSettingsV201"
+            }
         }
         self._logical_interconnect.update_settings(settings)
 

--- a/tests/unit/resources/networking/test_logical_switches.py
+++ b/tests/unit/resources/networking/test_logical_switches.py
@@ -67,7 +67,6 @@ class LogicalSwitchesTest(unittest.TestCase):
         resource_with_default_values = {
             "logicalSwitch": {
                 "name": "Test Logical Switch",
-                "type": "logical-switchV300"
             }
         }
         mock_create.return_value = {}
@@ -110,7 +109,6 @@ class LogicalSwitchesTest(unittest.TestCase):
         resource_with_default_values = {
             "logicalSwitch": {
                 "name": "Test Logical Switch",
-                "type": "logical-switchV300",
                 "uri": uri
             },
             "uri": "a_uri"

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -36,18 +36,18 @@ class ConnectionTest(unittest.TestCase):
             'Accept-Language': 'en_US'
         }
         self.default_headers = {
-            'X-API-Version': 300,
+            'X-API-Version': 800,
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         }
         self.default_headers_with_etag_validation_off = {
-            'X-API-Version': 300,
+            'X-API-Version': 800,
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'If-Match': '*'
         }
         self.merged_headers = {
-            'X-API-Version': 300,
+            'X-API-Version': 800,
             'Accept': 'application/json',
             'Content-Type': 'application/json',
             'Accept-Language': 'en_US'
@@ -109,11 +109,11 @@ class ConnectionTest(unittest.TestCase):
         self.connection.disable_etag_validation()
         self.assertEqual(self.default_headers_with_etag_validation_off, self.connection._headers)
 
-    def test_headers_with_api_version_300(self):
-        self.connection = connection(self.host, 300)
+    def test_headers_with_api_version_800(self):
+        self.connection = connection(self.host, 800)
 
         expected_headers = self.default_headers.copy()
-        expected_headers['X-API-Version'] = 300
+        expected_headers['X-API-Version'] = 800
         self.assertEqual(expected_headers, self.connection._headers)
 
     @patch.object(HTTPSConnection, 'request')
@@ -648,7 +648,7 @@ class ConnectionTest(unittest.TestCase):
             call('auth', 'LTIxNjUzMjc0OTUzzHoF7eEkZLEUWVA-fuOZP4VGA3U8e67E'),
             call('Content-Type', 'multipart/form-data; boundary=----------ThIs_Is_tHe_bouNdaRY_$'),
             call('Content-Length', 2621440),
-            call('X-API-Version', 300)]
+            call('X-API-Version', 800)]
 
         internal_conn = self.connection.get_connection.return_value
         internal_conn.putheader.assert_has_calls(expected_putheader_calls)
@@ -821,7 +821,7 @@ class ConnectionTest(unittest.TestCase):
 
         mock_conn.request.assert_called_once_with('POST', '/rest/test', 'body',
                                                   {'Content-Type': 'application/json',
-                                                   'X-API-Version': 300, 'Accept': 'application/json'})
+                                                   'X-API-Version': 800, 'Accept': 'application/json'})
 
         mock_conn.close.assert_called_once()
 
@@ -838,7 +838,7 @@ class ConnectionTest(unittest.TestCase):
 
         mock_conn.request.assert_called_once_with('POST', '/rest/test', 'body',
                                                   {'Content-Type': 'application/json',
-                                                   'X-API-Version': 300, 'Accept': 'application/json'})
+                                                   'X-API-Version': 800, 'Accept': 'application/json'})
 
         mock_conn.close.assert_called_once()
 
@@ -862,7 +862,7 @@ class ConnectionTest(unittest.TestCase):
 
         mock_conn.request.assert_called_with('POST', '/rest/test', 'body',
                                              {'Content-Type': 'application/json',
-                                              'X-API-Version': 300,
+                                              'X-API-Version': 800,
                                               'Accept': 'application/json'})
 
         mock_conn.close.assert_has_calls([call(), call()])
@@ -892,7 +892,7 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     @patch.object(connection, 'post')
     def test_login(self, mock_post, mock_get):
-        mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 1000}]
         mock_post.return_value = {'cat': 'task'}, {'sessionID': '123'}
 
         self.connection.login({})
@@ -910,7 +910,7 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     @patch.object(connection, 'post')
     def test_login_with_exception_in_post(self, mock_post, mock_get):
-        mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 1000}]
         mock_post.side_effect = HPOneViewException("Failed")
 
         self.assertRaises(HPOneViewException, self.connection.login, {})
@@ -918,7 +918,7 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     @patch.object(connection, 'put')
     def test_login_sessionID(self, mock_put, mock_get):
-        mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 1000}]
         mock_put.return_value = {'cat': 'task'}, {'sessionID': '123'}
 
         self.connection.login({"sessionID": "123"})
@@ -929,7 +929,7 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     @patch.object(connection, 'put')
     def test_login_username_password_sessionID(self, mock_put, mock_get):
-        mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 1000}]
         mock_put.return_value = {'cat': 'task'}, {'sessionID': '123'}
 
         self.connection.login({"userName": "administrator", "password": "", "sessionID": "123"})
@@ -940,7 +940,7 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     @patch.object(connection, 'put')
     def test_login_with_exception_in_put(self, mock_put, mock_get):
-        mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 400}]
         mock_put.side_effect = HPOneViewException("Failed")
 
         self.assertRaises(HPOneViewException, self.connection.login, {"sessionID": "123"})
@@ -948,14 +948,14 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     @patch.object(connection, 'put')
     def test_login_with_exception_in_put_username_password_sessionID(self, mock_put, mock_get):
-        mock_get.side_effect = [{'minimumVersion': 300, 'currentVersion': 400}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 400}]
         mock_put.side_effect = HPOneViewException("Failed")
         self.assertRaises(HPOneViewException, self.connection.login, {"userName": "administrator",
                                                                       "password": "", "sessionID": "123"})
 
     @patch.object(connection, 'get')
     def test_validate_version_exceeding_minimum(self, mock_get):
-        self.connection._apiVersion = 300
+        self.connection._apiVersion = 800
         mock_get.side_effect = [{'minimumVersion': 400, 'currentVersion': 400}]
 
         self.assertRaises(HPOneViewException, self.connection.validateVersion)
@@ -963,7 +963,7 @@ class ConnectionTest(unittest.TestCase):
     @patch.object(connection, 'get')
     def test_validate_version_exceeding_current(self, mock_get):
         self.connection._apiVersion = 400
-        mock_get.side_effect = [{'minimumVersion': 200, 'currentVersion': 300}]
+        mock_get.side_effect = [{'minimumVersion': 800, 'currentVersion': 400}]
 
         self.assertRaises(HPOneViewException, self.connection.validateVersion)
 

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -212,15 +212,15 @@ class OneViewClientTest(unittest.TestCase):
         mock_open.return_value = self.__mock_file_open(json_config_content)
         oneview_client = OneViewClient.from_json_file("config.json")
 
-        self.assertEqual(300, oneview_client.connection._apiVersion)
-        self.assertEqual(300, oneview_client.api_version)
+        self.assertEqual(800, oneview_client.connection._apiVersion)
+        self.assertEqual(800, oneview_client.api_version)
 
     @mock.patch.object(connection, 'login')
     @mock.patch(mock_builtin('open'))
     def test_configured_api_version(self, mock_open, mock_login):
         json_config_content = u"""{
           "ip": "172.16.102.59",
-          "api_version": 200,
+          "api_version": 1000,
           "credentials": {
             "userName": "administrator",
             "authLoginDomain": "",
@@ -230,8 +230,8 @@ class OneViewClientTest(unittest.TestCase):
         mock_open.return_value = self.__mock_file_open(json_config_content)
         oneview_client = OneViewClient.from_json_file("config.json")
 
-        self.assertEqual(200, oneview_client.connection._apiVersion)
-        self.assertEqual(200, oneview_client.api_version)
+        self.assertEqual(1000, oneview_client.connection._apiVersion)
+        self.assertEqual(1000, oneview_client.api_version)
 
     @mock.patch.object(connection, 'login')
     @mock.patch.object(connection, 'set_proxy')
@@ -244,7 +244,7 @@ class OneViewClientTest(unittest.TestCase):
                                                 authLoginDomain='',
                                                 sessionID=''))
         mock_set_proxy.assert_not_called()
-        self.assertEqual(300, oneview_client.connection._apiVersion)
+        self.assertEqual(800, oneview_client.connection._apiVersion)
 
     @mock.patch.object(connection, 'login')
     @mock.patch.object(connection, 'set_proxy')
@@ -257,7 +257,7 @@ class OneViewClientTest(unittest.TestCase):
                                                 authLoginDomain='',
                                                 sessionID='123'))
         mock_set_proxy.assert_not_called()
-        self.assertEqual(300, oneview_client.connection._apiVersion)
+        self.assertEqual(800, oneview_client.connection._apiVersion)
 
     @mock.patch.object(connection, 'login')
     @mock.patch.object(connection, 'set_proxy')
@@ -330,7 +330,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_only_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 300,
+        mock_cls.assert_called_once_with({'api_version': 800,
                                           'proxy': '',
                                           'timeout': None,
                                           'ip': '172.16.100.199',
@@ -394,9 +394,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_fcoe_networks_has_value(self):
         self.assertIsNotNone(self._oneview.fcoe_networks)
 
-    def test_lazy_loading_fcoe_networks(self):
+    def test_fcoe_networks_client(self):
         fcn = self._oneview.fcoe_networks
-        self.assertEqual(fcn, self._oneview.fcoe_networks)
+        self.assertNotEqual(fcn, self._oneview.fcoe_networks)
 
     def test_metric_streaming_has_right_type(self):
         self.assertIsInstance(self._oneview.metric_streaming, MetricStreaming)
@@ -404,9 +404,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_metric_streaming_has_value(self):
         self.assertIsNotNone(self._oneview.metric_streaming)
 
-    def test_lazy_loading_enclosure_groups(self):
+    def test_enclosure_groups_client(self):
         enclosure_groups = self._oneview.enclosure_groups
-        self.assertEqual(enclosure_groups, self._oneview.enclosure_groups)
+        self.assertNotEqual(enclosure_groups, self._oneview.enclosure_groups)
 
     def test_lazy_loading_tasks(self):
         tasks = self._oneview.tasks
@@ -415,13 +415,13 @@ class OneViewClientTest(unittest.TestCase):
     def test_should_return_new_connection_templates_obj(self):
         self.assertNotEqual(self._oneview.connection_templates, self._oneview.connection_templates)
 
-    def test_lazy_loading_switch_types(self):
+    def test_switch_types_client(self):
         switch_types = self._oneview.switch_types
-        self.assertEqual(switch_types, self._oneview.switch_types)
+        self.assertNotEqual(switch_types, self._oneview.switch_types)
 
-    def test_lazy_loading_network_sets(self):
+    def test_network_sets_client(self):
         network_sets = self._oneview.network_sets
-        self.assertEqual(network_sets, self._oneview.network_sets)
+        self.assertNotEqual(network_sets, self._oneview.network_sets)
 
     def test_lazy_loading_fabrics(self):
         fabrics = self._oneview.fabrics
@@ -438,9 +438,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_should_return_new_ethernet_networks_obj(self):
         self.assertNotEqual(self._oneview.ethernet_networks, self._oneview.ethernet_networks)
 
-    def test_lazy_loading_server_hardware(self):
+    def test_server_hardware_client(self):
         server_hardware = self._oneview.server_hardware
-        self.assertEqual(server_hardware, self._oneview.server_hardware)
+        self.assertNotEqual(server_hardware, self._oneview.server_hardware)
 
     def test_interconnect_link_topologies_has_right_type(self):
         self.assertIsInstance(self._oneview.interconnect_link_topologies, InterconnectLinkTopologies)
@@ -455,9 +455,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_sas_interconnect_types_has_right_type(self):
         self.assertIsInstance(self._oneview.sas_interconnect_types, SasInterconnectTypes)
 
-    def test_lazy_loading_sas_interconnect_types(self):
+    def test_sas_interconnect_types_client(self):
         sas_interconnect_types = self._oneview.sas_interconnect_types
-        self.assertEqual(sas_interconnect_types, self._oneview.sas_interconnect_types)
+        self.assertNotEqual(sas_interconnect_types, self._oneview.sas_interconnect_types)
 
     def test_interconnects_has_right_type(self):
         self.assertIsInstance(self._oneview.interconnects, Interconnects)
@@ -465,9 +465,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_interconnects_has_value(self):
         self.assertIsNotNone(self._oneview.interconnects)
 
-    def test_lazy_loading_interconnects(self):
+    def test_interconnects_client(self):
         interconnects = self._oneview.interconnects
-        self.assertEqual(interconnects, self._oneview.interconnects)
+        self.assertNotEqual(interconnects, self._oneview.interconnects)
 
     def test_certificate_authority_has_right_type(self):
         self.assertIsInstance(self._oneview.certificate_authority, CertificateAuthority)
@@ -483,9 +483,9 @@ class OneViewClientTest(unittest.TestCase):
         connections = self._oneview.connections
         self.assertEqual(connections, self._oneview.connections)
 
-    def test_lazy_loading_server_hardware_types(self):
+    def test_server_hardware_types_client(self):
         server_hardware_types = self._oneview.server_hardware_types
-        self.assertEqual(server_hardware_types, self._oneview.server_hardware_types)
+        self.assertNotEqual(server_hardware_types, self._oneview.server_hardware_types)
 
     def test_lazy_loading_id_pools_vsn_ranges(self):
         id_pools_vsn_ranges = self._oneview.id_pools_vsn_ranges
@@ -538,9 +538,9 @@ class OneViewClientTest(unittest.TestCase):
         id_pools = self._oneview.id_pools
         self.assertEqual(id_pools, self._oneview.id_pools)
 
-    def test_lazy_loading_logical_enclosures(self):
+    def test_logical_enclosures(self):
         logical_enclosures = self._oneview.logical_enclosures
-        self.assertEqual(logical_enclosures, self._oneview.logical_enclosures)
+        self.assertNotEqual(logical_enclosures, self._oneview.logical_enclosures)
 
     def test_should_return_new_interconnect_types_obj(self):
         self.assertNotEqual(self._oneview.interconnect_types, self._oneview.interconnect_types)
@@ -549,13 +549,13 @@ class OneViewClientTest(unittest.TestCase):
         logical_downlinks = self._oneview.logical_downlinks
         self.assertEqual(logical_downlinks, self._oneview.logical_downlinks)
 
-    def test_lazy_loading_storage_systems(self):
+    def test_storage_systems_client(self):
         storage_systems = self._oneview.storage_systems
-        self.assertEqual(storage_systems, self._oneview.storage_systems)
+        self.assertNotEqual(storage_systems, self._oneview.storage_systems)
 
-    def test_lazy_loading_storage_pools(self):
+    def test_storage_pools_client(self):
         storage_pools = self._oneview.storage_pools
-        self.assertEqual(storage_pools, self._oneview.storage_pools)
+        self.assertNotEqual(storage_pools, self._oneview.storage_pools)
 
     def test_lazy_loading_firmware_drivers(self):
         firmware_drivers = self._oneview.firmware_drivers
@@ -625,9 +625,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_logical_interconnect_groups_has_value(self):
         self.assertIsNotNone(self._oneview.logical_interconnect_groups)
 
-    def test_lazy_loading_logical_interconnect_groups(self):
+    def test_logical_interconnect_groups_client(self):
         logical_interconnect_groups = self._oneview.logical_interconnect_groups
-        self.assertEqual(logical_interconnect_groups, self._oneview.logical_interconnect_groups)
+        self.assertNotEqual(logical_interconnect_groups, self._oneview.logical_interconnect_groups)
 
     def test_logical_switch_groups_has_right_type(self):
         self.assertIsInstance(self._oneview.logical_switch_groups, LogicalSwitchGroups)
@@ -659,9 +659,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_sas_logical_interconnects_has_right_type(self):
         self.assertIsInstance(self._oneview.sas_logical_interconnects, SasLogicalInterconnects)
 
-    def test_lazy_loading_sas_logical_interconnects(self):
+    def test_sas_logical_interconnects_client(self):
         sas_logical_interconnects = self._oneview.sas_logical_interconnects
-        self.assertEqual(sas_logical_interconnects, self._oneview.sas_logical_interconnects)
+        self.assertNotEqual(sas_logical_interconnects, self._oneview.sas_logical_interconnects)
 
     def test_storage_volume_templates_has_right_type(self):
         self.assertIsInstance(self._oneview.storage_volume_templates, StorageVolumeTemplates)
@@ -669,9 +669,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_storage_volume_templates_has_value(self):
         self.assertIsNotNone(self._oneview.storage_volume_templates)
 
-    def test_lazy_loading_storage_volume_templates(self):
+    def test_storage_volume_templates_client(self):
         storage_volume_templates = self._oneview.storage_volume_templates
-        self.assertEqual(storage_volume_templates, self._oneview.storage_volume_templates)
+        self.assertNotEqual(storage_volume_templates, self._oneview.storage_volume_templates)
 
     def test_storage_volume_attachments_has_right_type(self):
         self.assertIsInstance(self._oneview.storage_volume_attachments, StorageVolumeAttachments)
@@ -679,9 +679,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_storage_volume_attachments_has_value(self):
         self.assertIsNotNone(self._oneview.storage_volume_attachments)
 
-    def test_lazy_loading_storage_volume_attachments(self):
+    def test_storage_volume_attachments_client(self):
         storage_volume_attachments = self._oneview.storage_volume_attachments
-        self.assertEqual(storage_volume_attachments, self._oneview.storage_volume_attachments)
+        self.assertNotEqual(storage_volume_attachments, self._oneview.storage_volume_attachments)
 
     def test_should_return_new_uplink_sets_obj(self):
         self.assertNotEqual(self._oneview.uplink_sets, self._oneview.uplink_sets)
@@ -716,9 +716,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_sas_logical_interconnect_groups_has_right_type(self):
         self.assertIsInstance(self._oneview.sas_logical_interconnect_groups, SasLogicalInterconnectGroups)
 
-    def test_lazy_loading_sas_logical_interconnect_groups(self):
+    def test_sas_logical_interconnect_groups_client(self):
         sas_logical_interconnect_groups = self._oneview.sas_logical_interconnect_groups
-        self.assertEqual(sas_logical_interconnect_groups, self._oneview.sas_logical_interconnect_groups)
+        self.assertNotEqual(sas_logical_interconnect_groups, self._oneview.sas_logical_interconnect_groups)
 
     def test_login_details_has_right_type(self):
         self.assertIsInstance(self._oneview.login_details, LoginDetails)
@@ -739,9 +739,8 @@ class OneViewClientTest(unittest.TestCase):
     def test_volumes_has_value(self):
         self.assertIsNotNone(self._oneview.volumes)
 
-    def test_lazy_loading_volumes(self):
-        copy_volumes = self._oneview.volumes
-        self.assertEqual(copy_volumes, self._oneview.volumes)
+    def test_volumes_client(self):
+        self.assertNotEqual(self._oneview.volumes, self._oneview.volumes)
 
     def test_sas_logical_jbod_attachments_right_type(self):
         self.assertIsInstance(self._oneview.sas_logical_jbod_attachments, SasLogicalJbodAttachments)
@@ -782,14 +781,14 @@ class OneViewClientTest(unittest.TestCase):
 
     def test_lazy_loading_managed_sans(self):
         managed_sans = self._oneview.managed_sans
-        self.assertEqual(managed_sans, self._oneview.managed_sans)
+        self.assertNotEqual(managed_sans, self._oneview.managed_sans)
 
     def test_sas_interconnects_has_right_type(self):
         self.assertIsInstance(self._oneview.sas_interconnects, SasInterconnects)
 
-    def test_lazy_loading_sas_interconnects(self):
+    def test_sas_interconnects_client(self):
         sas_interconnects = self._oneview.sas_interconnects
-        self.assertEqual(sas_interconnects, self._oneview.sas_interconnects)
+        self.assertNotEqual(sas_interconnects, self._oneview.sas_interconnects)
 
     def test_drive_enclosure_has_right_type(self):
         self.assertIsInstance(self._oneview.drive_enclosures, DriveEnclosures)
@@ -808,9 +807,9 @@ class OneViewClientTest(unittest.TestCase):
     def test_internal_link_sets_has_right_type(self):
         self.assertIsInstance(self._oneview.internal_link_sets, InternalLinkSets)
 
-    def test_lazy_loading_internal_link_sets(self):
+    def test_internal_link_sets_client(self):
         internal_links = self._oneview.internal_link_sets
-        self.assertEqual(internal_links, self._oneview.internal_link_sets)
+        self.assertNotEqual(internal_links, self._oneview.internal_link_sets)
 
     def test_index_resources_has_right_type(self):
         self.assertIsInstance(self._oneview.index_resources, IndexResources)


### PR DESCRIPTION
### Description
Changed SDK default API version from 300 to 800
Updated test cases to accommodate the default API version change
Removed 200,300,500 and 600 API versions from README and endpoint support 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
