### PR TITLE
Fix download

### DIFF
--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -167,11 +167,11 @@ class connection(object):
                     self.__handle_download_error(resp, conn)
 
                 if resp.status == 302:
-                    self.download_to_stream(stream_writer=stream_writer,
-                                            url=resp.getheader('Location'),
-                                            body=body,
-                                            method=method,
-                                            custom_headers=http_headers)
+                    return self.download_to_stream(stream_writer=stream_writer,
+                                                   url=resp.getheader('Location'),
+                                                   body=body,
+                                                   method=method,
+                                                   custom_headers=http_headers)
 
                 tempbytes = True
                 while tempbytes:

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -166,6 +166,13 @@ class connection(object):
                 if resp.status >= 400:
                     self.__handle_download_error(resp, conn)
 
+                if resp.status == 302:
+                    self.download_to_stream(stream_writer=stream_writer,
+                                            url=resp.getheader('Location'),
+                                            body=body,
+                                            method=method,
+                                            custom_headers=http_headers)
+
                 tempbytes = True
                 while tempbytes:
                     tempbytes = resp.read(chunk_size)

--- a/hpOneView/resources/resource.py
+++ b/hpOneView/resources/resource.py
@@ -1660,7 +1660,10 @@ class ResourceClient(object):
             bool: Indicates if the file was successfully downloaded.
         """
         with open(file_path, 'wb') as file:
-            return self._connection.download_to_stream(file, uri)
+            return self._connection.download_to_stream(
+                file,
+                uri,
+                custom_headers={"Accept": "application/octetstream;q=0.8, application/json"})
 
     def __validate_resource_uri(self, path):
         if self._uri not in path:

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -2349,7 +2349,7 @@ class ResourceClientTest(unittest.TestCase):
 
         self.resource_client.download(uri, file_path)
 
-        mock_download_to_stream.assert_called_once_with(mock.ANY, uri)
+        mock_download_to_stream.assert_called_once_with(mock.ANY, uri, custom_headers=mock.ANY)
 
     @mock.patch.object(connection, 'download_to_stream')
     @mock.patch(mock_builtin('open'))
@@ -2362,7 +2362,7 @@ class ResourceClientTest(unittest.TestCase):
         self.resource_client.download(uri, file_path)
 
         mock_open.assert_called_once_with(file_path, 'wb')
-        mock_download_to_stream.assert_called_once_with(fake_file, mock.ANY)
+        mock_download_to_stream.assert_called_once_with(fake_file, uri, custom_headers=mock.ANY)
 
     @mock.patch.object(connection, 'download_to_stream')
     @mock.patch(mock_builtin('open'))


### PR DESCRIPTION
### Description
OneView returns HTTP status code 302 when a GET request is executed on a given backup's **downloadUri**. This PR adds support for handling the redirect request in download_to_stream method of connections.py

Adding custom header to download method in backup resource module. The expectation is to have `application/octetstream` along with `application/json` in the **Accept** header

### Issues Resolved
#18 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`). Note: Checked with Py 3.8.1
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
