### PR TITLE
Add key 1200 with value RESTOREV1000 in restores.py

### DIFF
--- a/hpOneView/resources/settings/restores.py
+++ b/hpOneView/resources/settings/restores.py
@@ -35,7 +35,8 @@ class Restores(object):
 
     DEFAULT_VALUES = {
         '200': {"type": "RESTORE"},
-        '300': {"type": "RESTORE"}
+        '300': {"type": "RESTORE"},
+        '1200': {"type": "RESTOREV1000"}
     }
 
     def __init__(self, con):


### PR DESCRIPTION
### Description
Restoring the appliance when the API Version is 1200 would fail with the error `missing json type field`. This change addresses this issue.

### Issues Resolved
#23 
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
