### PR TITLE
Added resource for server certificate for API 800, 1000 and 1200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 Extends support of the SDK to OneView REST API version 800, 1000 and 1200.
 
 #### Features supported
-- Hypervisor Managers
 - Certificates Server
+- Hypervisor Managers
 
 # 5.0.0
 #### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Extends support of the SDK to OneView REST API version 800, 1000 and 1200.
 
 #### Features supported
 - Hypervisor Managers
+- Certificates Server
 
 # 5.0.0
 #### Notes

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -25,6 +25,12 @@
 |<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/connection-templates/{id}</sub>                                               |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/connection-templates/{id}</sub>                                               |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|     **Certificates Server**
+|<sub>/rest/certificates/servers</sub>                                                    |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/certificates/https/remote/example.com</sub>                                   |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Enclosure Groups**
 |<sub>/rest/enclosure-groups</sub>                                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/enclosure-groups</sub>                                                        | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/certificates_server.py
+++ b/examples/certificates_server.py
@@ -33,12 +33,12 @@ remote_server_options = {
 }
 
 options = {
-    "certificateDetails":[
-      {
-         "aliasName":"vcenter",
-         "base64Data":"",
-         "type":"CertificateDetailV2"
-      }
+    "certificateDetails": [
+        {
+            "aliasName": "vcenter",
+            "base64Data": "",
+            "type": "CertificateDetailV2"
+        }
     ],
 }
 
@@ -58,12 +58,14 @@ print(ca_certificate)
 options['certificateDetails'][0]['base64Data'] = ca_certificate
 options['certificateDetails'][0]['type'] = remote_server_cert['certificateDetails'][0]['type']
 server_certificate = certificate_server.create(data=options)
-print("\nAdded a server certificate with aliasName: {}.\n  uri = {}".format(server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
+print("\nAdded a server certificate with aliasName: {}.\n  uri = {}".format(
+      server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
 
 # Fetch certificate by alias name
 print("\nGet server certificate by alias name")
 server_cert_by_alias = certificate_server.get_by_aliasName("vcenter")
-print("\nFound server certificate by aliasName: {}.\n  uri = {}".format(server_cert_by_alias['certificateDetails'][0]['aliasName'], server_cert_by_alias['uri']))
+print("\nFound server certificate by aliasName: {}.\n  uri = {}".format(
+      server_cert_by_alias['certificateDetails'][0]['aliasName'], server_cert_by_alias['uri']))
 
 # Get by uri
 print("\nGet a server certificate by uri")
@@ -74,7 +76,8 @@ pprint(server_cert_by_uri.data)
 print("\nUpdate recently created server certificate")
 data_to_update = {'name': 'Updated vcenter'}
 server_certificate.update(data=data_to_update)
-print("\nUpdated server certificate {} successfully.\n".format(server_certificate.data['certificateDetails'][0]['aliasName']))
+print("\nUpdated server certificate {} successfully.\n".format(
+      server_certificate.data['certificateDetails'][0]['aliasName']))
 
 # Delete the added server certificate
 server_certificate.delete()

--- a/examples/certificates_server.py
+++ b/examples/certificates_server.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+from pprint import pprint
+
+from config_loader import try_load_from_file
+from hpOneView.oneview_client import OneViewClient
+
+config = {
+    "ip": "",
+    "credentials": {
+        "userName": "",
+        "password": ""
+    }
+}
+
+remote_server_options = {
+    "name": "172.18.13.11",
+}
+
+options = {
+    "certificateDetails":[
+      {
+         "aliasName":"vcenter",
+         "base64Data":"",
+         "type":"CertificateDetailV2"
+      }
+    ],
+}
+
+
+# Try load config from a file (if there is a config file)
+config = try_load_from_file(config)
+oneview_client = OneViewClient.config()
+certificate_server = oneview_client.certificates_server
+
+# Fetch server certificate of remote server
+print("\nGet server certificate of remote server by ip address")
+remote_server_cert = certificate_server.get_remote(remote_server_options['name'])
+ca_certificate = remote_server_cert['certificateDetails'][0]['base64Data']
+print(ca_certificate)
+
+# Add a server certificate with the options provided
+options['certificateDetails'][0]['base64Data'] = ca_certificate
+options['certificateDetails'][0]['type'] = remote_server_cert['certificateDetails'][0]['type']
+server_certificate = certificate_server.create(data=options)
+print("\nAdded a server certificate with aliasName: {}.\n  uri = {}".format(server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
+
+# Fetch certificate by alias name
+print("\nGet server certificate by alias name")
+server_cert_by_alias = certificate_server.get_by_aliasName("vcenter")
+print("\nFound server certificate by aliasName: {}.\n  uri = {}".format(server_cert_by_alias['certificateDetails'][0]['aliasName'], server_cert_by_alias['uri']))
+
+# Get by uri
+print("\nGet a server certificate by uri")
+server_cert_by_uri = certificate_server.get_by_uri(server_certificate.data['uri'])
+pprint(server_cert_by_uri.data)
+
+# Update alias name of recently added certificate
+print("\nUpdate recently created server certificate")
+data_to_update = {'name': 'Updated vcenter'}
+server_certificate.update(data=data_to_update)
+print("\nUpdated server certificate {} successfully.\n".format(server_certificate.data['certificateDetails'][0]['aliasName']))
+
+# Delete the added server certificate
+server_certificate.delete()
+print("\nSuccessfully deleted server certificate")

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -108,6 +108,7 @@ from hpOneView.resources.settings.appliance_node_information import ApplianceNod
 from hpOneView.resources.settings.appliance_time_and_locale_configuration import ApplianceTimeAndLocaleConfiguration
 from hpOneView.resources.settings.versions import Versions
 from hpOneView.resources.hypervisors.hypervisor_managers import HypervisorManagers
+from hpOneView.resources.security.certificates_server import CertificatesServer
 
 ONEVIEW_CLIENT_INVALID_PROXY = 'Invalid Proxy format'
 
@@ -200,6 +201,7 @@ class OneViewClient(object):
         self.__login_details = None
         self.__licenses = None
         self.__hypervisor_managers = None
+        self.__certificates_server = None
 
     @classmethod
     def from_json_file(cls, file_name):
@@ -1183,3 +1185,13 @@ class OneViewClient(object):
             HypervisorManagers
         """
         return HypervisorManagers(self.__connection)
+
+    @property
+    def certificates_server(self):
+        """
+        Gets the Certificates Server API client.
+
+        Returns:
+            Server Certificate:
+        """
+        return CertificatesServer(self.__connection)

--- a/hpOneView/resources/security/certificates_server.py
+++ b/hpOneView/resources/security/certificates_server.py
@@ -54,7 +54,9 @@ class CertificatesServer(Resource):
             data: Fields passed to create the resource.
             timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
                 in OneView; it just stops waiting for its completion.
-        Returns:
+            custom_headers: Allows set specific HTTP headers.
+
+        Return:
             Created resource.
         """
         if not data:
@@ -79,7 +81,6 @@ class CertificatesServer(Resource):
 
         Return:
              dict: Certificate chain of remote server
-
         """
         uri = "{0}/https/remote/{1}".format(self.URI, remote_address)
         return self._helper.do_get(uri)

--- a/hpOneView/resources/security/certificates_server.py
+++ b/hpOneView/resources/security/certificates_server.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+
+standard_library.install_aliases()
+
+
+from hpOneView.resources.resource import Resource
+
+
+class CertificatesServer(Resource):
+    """
+    The Certificates Servers resource provides REST APIs for configuration of device or
+    server certificates for the appliance to establish SSL communication with other managed network entities.
+
+    Import, Update and Delete APIs are asynchronous and GET API is synchronous.
+
+    """
+    URI = '/rest/certificates'
+
+    DEFAULT_VALUES = {
+        '600': {"type": "CertificateInfoV2"},
+        '800': {"type": "CertificateInfoV2"},
+        '1000': {"type": "CertificateInfoV2"},
+        '1200': {"type": "CertificateInfoV2"}
+    }
+
+    def __init__(self, connection, data=None):
+        super(CertificatesServer, self).__init__(connection, data)
+
+    def create(self, data=None, timeout=-1, custom_headers=None):
+        """Makes a POST request to create a resource when a request body is required.
+
+        Args:
+            data: Fields passed to create the resource.
+            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
+                in OneView; it just stops waiting for its completion.
+        Returns:
+            Created resource.
+        """
+        if not data:
+            data = {}
+
+        default_values = self._get_default_values()
+        data = self._helper.update_resource_fields(data, default_values)
+        uri_create = "{}/servers".format(self.URI)
+
+        resource_data = self._helper.create(data, uri_create, timeout, custom_headers)
+        new_resource = self.new(self._connection, resource_data)
+
+        return new_resource
+
+    def get_remote(self, remote_address):
+        """
+        Retrieves the device or server certificate and certificate chain of the specified device or server.
+
+        Args:
+            remote_address:
+                Address of remote server
+
+        Return:
+             dict: Certificate chain of remote server
+
+        """
+        uri = "{0}/https/remote/{1}".format(self.URI, remote_address)
+        return self._helper.do_get(uri)
+
+    def get_by_aliasName(self, alias_name):
+        """
+        Retrieves the device or server certificate, already trusted in the appliance,
+        with the specified aliasName.
+
+        Args:
+            alias_name (str): Alias name.
+
+        Return:
+            dict: Certificate of trusted appliance
+        """
+        uri = "{0}/servers/{1}".format(self.URI, alias_name)
+        return self._helper.do_get(uri)

--- a/hpOneView/resources/security/certificates_server.py
+++ b/hpOneView/resources/security/certificates_server.py
@@ -38,7 +38,6 @@ class CertificatesServer(Resource):
     URI = '/rest/certificates'
 
     DEFAULT_VALUES = {
-        '600': {"type": "CertificateInfoV2"},
         '800': {"type": "CertificateInfoV2"},
         '1000': {"type": "CertificateInfoV2"},
         '1200': {"type": "CertificateInfoV2"}
@@ -47,29 +46,20 @@ class CertificatesServer(Resource):
     def __init__(self, connection, data=None):
         super(CertificatesServer, self).__init__(connection, data)
 
-    def create(self, data=None, timeout=-1, custom_headers=None):
-        """Makes a POST request to create a resource when a request body is required.
+    def create(self, data=None, timeout=-1):
+        """
+        Makes a POST request to create a server certificate resource.
 
         Args:
             data: Fields passed to create the resource.
             timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
                 in OneView; it just stops waiting for its completion.
-            custom_headers: Allows set specific HTTP headers.
 
         Return:
-            Created resource.
+            Created certificate resource.
         """
-        if not data:
-            data = {}
-
-        default_values = self._get_default_values()
-        data = self._helper.update_resource_fields(data, default_values)
         uri_create = "{}/servers".format(self.URI)
-
-        resource_data = self._helper.create(data, uri_create, timeout, custom_headers)
-        new_resource = self.new(self._connection, resource_data)
-
-        return new_resource
+        return super(CertificatesServer, self).create(data, uri=uri_create, timeout=timeout)
 
     def get_remote(self, remote_address):
         """

--- a/tests/unit/resources/security/test_certificates_server.py
+++ b/tests/unit/resources/security/test_certificates_server.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+###
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+
+from unittest import TestCase
+
+import mock
+
+from hpOneView.connection import connection
+from hpOneView.resources.security.certificates_server import CertificatesServer
+from hpOneView.resources.resource import Resource, ResourceHelper
+
+
+class CertificatesServerTest(TestCase):
+
+    def setUp(self):
+        self.host = '127.0.0.1'
+        self.connection = connection(self.host)
+        self._certificate_server = CertificatesServer(self.connection)
+        self.uri = "/rest/certificates/servers"
+        self._certificate_server.data = {"uri": self.uri}
+
+    @mock.patch.object(ResourceHelper, 'create')
+    def test_create_called_once(self, mock_create):
+        resource = dict(
+            type="CertificateInfoV2",
+            certificateDetails=["test1", "test2"],
+        )
+
+        resource_rest_call = resource.copy()
+        mock_create.return_value = {}
+
+        self._certificate_server.create(resource, timeout=20)
+        mock_create.assert_called_once_with(resource_rest_call, self.uri, 20, None)
+
+    @mock.patch.object(ResourceHelper, 'create')
+    def test_create_called_once_with_defaults(self, mock_create):
+        resource = dict(
+            type="CertificateInfoV2",
+            certificateDetails=["test1", "test2"],
+        )
+
+        resource_rest_call = resource.copy()
+        mock_create.return_value = {}
+
+        self._certificate_server.create(resource)
+        mock_create.assert_called_once_with(resource_rest_call, self.uri, -1, None)
+
+    @mock.patch.object(ResourceHelper, 'do_get')
+    def test_get_remote_server_called_once(self, mock_get_remote):
+        remote_server = "1.2.3.4"
+        uri_rest_call = "/rest/certificates/https/remote/{}".format(remote_server)
+
+        self._certificate_server.get_remote(remote_server)
+        mock_get_remote.assert_called_once_with(uri_rest_call)
+
+
+    @mock.patch.object(ResourceHelper, 'do_get')
+    def test_get_by_aliasName_called_once(self, mock_get_by_aliasName):
+        uri_rest_call = "{0}/{1}".format(self.uri, "test1")
+        self._certificate_server.get_by_aliasName("test1")
+        mock_get_by_aliasName.assert_called_once_with(uri_rest_call)
+
+    @mock.patch.object(Resource, 'ensure_resource_data')
+    @mock.patch.object(ResourceHelper, 'update')
+    def test_update_called_once_with_default(self, mock_update, mock_ensure_client):
+        resource = {
+            "aliasName": "new certificate",
+            "uri": self.uri
+        }
+        self._certificate_server.update(resource)
+        mock_update.assert_called_once_with(resource, self.uri, False, -1, None)
+
+    @mock.patch.object(Resource, 'ensure_resource_data')
+    @mock.patch.object(ResourceHelper, 'update')
+    def test_update_called_once(self, mock_update, mock_ensure_client):
+        resource = {
+            "aliasName": "new certificate",
+            "uri": self.uri
+        }
+        self._certificate_server.update(resource, 20)
+        mock_update.assert_called_once_with(resource, self.uri, False, 20, None)
+
+    @mock.patch.object(ResourceHelper, 'delete')
+    def test_delete_called_once(self, mock_delete):
+        self._certificate_server.delete()
+        mock_delete.assert_called_once_with(self.uri, custom_headers=None, force=False, timeout=-1)

--- a/tests/unit/resources/security/test_certificates_server.py
+++ b/tests/unit/resources/security/test_certificates_server.py
@@ -67,7 +67,6 @@ class CertificatesServerTest(TestCase):
         self._certificate_server.get_remote(remote_server)
         mock_get_remote.assert_called_once_with(uri_rest_call)
 
-
     @mock.patch.object(ResourceHelper, 'do_get')
     def test_get_by_aliasName_called_once(self, mock_get_by_aliasName):
         uri_rest_call = "{0}/{1}".format(self.uri, "test1")

--- a/tests/unit/resources/security/test_certificates_server.py
+++ b/tests/unit/resources/security/test_certificates_server.py
@@ -33,7 +33,7 @@ class CertificatesServerTest(TestCase):
         self.uri = "/rest/certificates/servers"
         self._certificate_server.data = {"uri": self.uri}
 
-    @mock.patch.object(ResourceHelper, 'create')
+    @mock.patch.object(Resource, 'create')
     def test_create_called_once(self, mock_create):
         resource = dict(
             type="CertificateInfoV2",
@@ -44,9 +44,9 @@ class CertificatesServerTest(TestCase):
         mock_create.return_value = {}
 
         self._certificate_server.create(resource, timeout=20)
-        mock_create.assert_called_once_with(resource_rest_call, self.uri, 20, None)
+        mock_create.assert_called_once_with(resource_rest_call, uri=self.uri, timeout=20)
 
-    @mock.patch.object(ResourceHelper, 'create')
+    @mock.patch.object(Resource, 'create')
     def test_create_called_once_with_defaults(self, mock_create):
         resource = dict(
             type="CertificateInfoV2",
@@ -57,7 +57,7 @@ class CertificatesServerTest(TestCase):
         mock_create.return_value = {}
 
         self._certificate_server.create(resource)
-        mock_create.assert_called_once_with(resource_rest_call, self.uri, -1, None)
+        mock_create.assert_called_once_with(resource_rest_call, uri=self.uri, timeout=-1)
 
     @mock.patch.object(ResourceHelper, 'do_get')
     def test_get_remote_server_called_once(self, mock_get_remote):

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -935,6 +935,6 @@ class OneViewClientTest(unittest.TestCase):
     def test_certificates_server_has_right_type(self):
         self.assertIsInstance(self._oneview.certificates_server, CertificatesServer)
 
-    def test_lazy_loading_certificates_server(self):
+    def test_certificates_server_client(self):
         certificates_server = self._oneview.certificates_server
         self.assertNotEqual(certificates_server, self._oneview.certificates_server)

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,6 +80,7 @@ from hpOneView.resources.settings.versions import Versions
 from tests.test_utils import mock_builtin
 from hpOneView.resources.settings.licenses import Licenses
 from hpOneView.resources.hypervisors.hypervisor_managers import HypervisorManagers
+from hpOneView.resources.security.certificates_server import CertificatesServer
 
 OS_ENVIRON_CONFIG_MINIMAL = {
     'ONEVIEWSDK_IP': '172.16.100.199',
@@ -930,3 +931,10 @@ class OneViewClientTest(unittest.TestCase):
     def test_lazy_loading_hypervisor_managers(self):
         hypervisor_managers = self._oneview.hypervisor_managers
         self.assertNotEqual(hypervisor_managers, self._oneview.hypervisor_managers)
+
+    def test_certificates_server_has_right_type(self):
+        self.assertIsInstance(self._oneview.certificates_server, CertificatesServer)
+
+    def test_lazy_loading_certificates_server(self):
+        certificates_server = self._oneview.certificates_server
+        self.assertNotEqual(certificates_server, self._oneview.certificates_server)


### PR DESCRIPTION
### Description
Added resource file, UTs and example file for server certificate for API 800, 1000 and 1200

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
