### PR TITLE
Refactored Appliance SNMPv1 trap destinations resource for API 800, 1000 and 1200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.2.0 (unreleased)
+#### Notes
+Extends support of the SDK to OneView REST API version 800, 1000 and 1200.
+
+#### Features supported
+- Appliance SNMPv1 Trap Destinations
+
 # 5.1.0
 #### Notes
 Extends support of the SDK to OneView REST API version 800, 1000 and 1200.

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -20,6 +20,13 @@
 
 | Endpoints                                                                               | Verb     |  V800                 | V1000               | V1200
 | --------------------------------------------------------------------------------------- | -------- |  :------------------: | :------------------:| :------------------: |
+|     **Appliance SNMPv1 Trap Destinations**
+|<sub>/rest/appliance/trap-destinations</sub>                                             |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/appliance/trap-destinations/validation</sub>                                  |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/appliance/trap-destinations/{id}</sub>                                        |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/appliance/trap-destinations/{id}</sub>                                        |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/appliance/trap-destinations/{id}</sub>                                        |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/appliance/trap-destinations/{id}</sub>                                        |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Connection Templates**
 |<sub>/rest/connection-templates</sub>                                                    |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/appliance_device_snmp_v1_trap_destinations.py
+++ b/examples/appliance_device_snmp_v1_trap_destinations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,45 +33,61 @@ options = {
     "port": 162
 }
 
+destination_ip = '2.2.2.2'
+
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
-
 oneview_client = OneViewClient(config)
+appliance_device_snmp_v1_trap_destinations = oneview_client.appliance_device_snmp_v1_trap_destinations
+
+# Lists the appliance device SNMP v1 Trap Destination
+print("\n Get list of appliance SNMP v1 trap destination")
+snmp_v1_trap_all = appliance_device_snmp_v1_trap_destinations.get_all()
+for snmp_trap in snmp_v1_trap_all:
+    print('  - {}: {}'.format(snmp_trap['destination'], snmp_trap['uri']))
+
+# Add validation od snmp v1 trap
+print("\n Validate SNMP v1 trap destination")
+validate_options = options.copy()
+validate_options.pop('port')
+validate_options['uri'] = snmp_v1_trap_all[0]['uri']
+validate_result = appliance_device_snmp_v1_trap_destinations.create_validation(validate_options)
+pprint(validate_result.data)
 
 # Add appliance device SNMP v1 Trap Destination
-snmp_v1_trap = oneview_client.appliance_device_snmp_v1_trap_destinations.create(options)
-snmp_v1_trap_uri = snmp_v1_trap['uri']
-print("\n## Create appliance SNMP v1 trap destination successfully!")
-pprint(snmp_v1_trap)
+snmp_v1_trap = appliance_device_snmp_v1_trap_destinations.create(options)
+print("\n Created appliance SNMP v1 trap destination successfully!")
+pprint(snmp_v1_trap.data)
 
 # Add appliance device SNMP v1 Trap Destination with ID
 trap_id = 9
-snmp_v1_trap = oneview_client.appliance_device_snmp_v1_trap_destinations.create(options, trap_id)
-print("\n## Create appliance SNMP v1 trap destination successfully!")
-pprint(snmp_v1_trap)
+options['destination'] = destination_ip
+snmp_v1_trap_id = appliance_device_snmp_v1_trap_destinations.create(options, trap_id)
+print("\n Created appliance SNMP v1 trap destination by id successfully!")
+pprint(snmp_v1_trap_id.data)
 
-# Lists the appliance device SNMP v1 Trap Destination
-snmp_v1_trap = oneview_client.appliance_device_snmp_v1_trap_destinations.get_all()
-print("\n## Got appliance SNMP v1 trap destination successfully!")
-pprint(snmp_v1_trap)
+# Get the appliance device SNMP v1 Trap Destination by id
+print("\n Get appliance SNMP v1 trap destination by id")
+snmp_v1_trap_by_id = appliance_device_snmp_v1_trap_destinations.get_by_id(1)
+pprint(snmp_v1_trap_by_id)
 
 # Lists the appliance device SNMP v1 Trap Destination by destination (unique)
-snmp_v1_trap = oneview_client.appliance_device_snmp_v1_trap_destinations.get_by('destination', '1.1.1.1')
-print("\n## Got appliance SNMP v1 trap by destination successfully!")
-pprint(snmp_v1_trap)
+print("\n## Get appliance SNMP v1 trap by destination..")
+snmp_v1_traps = appliance_device_snmp_v1_trap_destinations.get_by('destination', options['destination'])
+for snmp_trap in snmp_v1_traps:
+    print(' - {} : {}'.format(snmp_trap['destination'], snmp_trap['communityString']))
 
 # Get by URI
-print("Find an SNMP v1 trap destination by URI")
-snmp_v1_trap = oneview_client.appliance_device_snmp_v1_trap_destinations.get(snmp_v1_trap_uri)
-pprint(snmp_v1_trap)
+print("\n Find an SNMP v1 trap destination by URI")
+snmp_v1_trap = appliance_device_snmp_v1_trap_destinations.get_by_uri(snmp_v1_trap.data['uri'])
+pprint(snmp_v1_trap.data)
 
 # Change appliance device SNMP v1 Trap Destination - Only Community String and Port can be changed
-snmp_v1_trap['communityString'] = 'testTwo'
-snmp_v1_trap = oneview_client.appliance_device_snmp_v1_trap_destinations.update(snmp_v1_trap)
+data = {'communityString': 'testTwo'}
+snmp_v1_trap = snmp_v1_trap.update(data)
 print("\n## Update appliance SNMP v1 trap destination successfully!")
-pprint(snmp_v1_trap)
+pprint(snmp_v1_trap.data)
 
 # Delete Created Entry
-del_result = oneview_client.appliance_device_snmp_v1_trap_destinations.delete(snmp_v1_trap)
+snmp_v1_trap.delete()
 print("\n## Delete appliance SNMP v1 trap destination successfully!")
-pprint(del_result)

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -1078,9 +1078,7 @@ class OneViewClient(object):
         Returns:
             ApplianceDeviceSNMPv1TrapDestinations:
         """
-        if not self.__appliance_device_snmp_v1_trap_destinations:
-            self.__appliance_device_snmp_v1_trap_destinations = ApplianceDeviceSNMPv1TrapDestinations(self.__connection)
-        return self.__appliance_device_snmp_v1_trap_destinations
+        return ApplianceDeviceSNMPv1TrapDestinations(self.__connection)
 
     @property
     def appliance_device_snmp_v3_trap_destinations(self):

--- a/hpOneView/resources/settings/appliance_device_snmp_v1_trap_destinations.py
+++ b/hpOneView/resources/settings/appliance_device_snmp_v1_trap_destinations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,50 +19,91 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
 from future import standard_library
 
 standard_library.install_aliases()
 
-from hpOneView.resources.resource import ResourceClient
+
+from hpOneView.resources.resource import Resource
 
 
-class ApplianceDeviceSNMPv1TrapDestinations(object):
+class ApplianceDeviceSNMPv1TrapDestinations(Resource):
     """
     ApplianceDeviceSNMPv1TrapDestinations API client.
-    The appliance has the ability to forward events received from monitored or managed server hardware to the specified destinations as SNMPv1 traps.
+
+    The appliance has the ability to forward events received from monitored or managed
+    server hardware to the specified destinations as SNMPv1 traps.
     """
     URI = '/rest/appliance/trap-destinations'
 
-    def __init__(self, con):
-        self._client = ResourceClient(con, self.URI)
+    def __init__(self, connection, data=None):
+        super(ApplianceDeviceSNMPv1TrapDestinations, self).__init__(connection, data)
 
-    def create(self, resource, id=None, timeout=-1):
+    def get_by_id(self, id):
+        """
+        Retrieves the trap destination based on the id specified.
+
+        Args:
+            id (int): id of the snmp_v1 trap resource
+
+        Return:
+            dict: SNMPv1 trap destination
+
+        """
+        uri = "{0}/{1}".format(self.URI, id)
+        return self._helper.do_get(uri)
+
+
+    def create_validation(self, data=None, timeout=-1):
+        """
+        Validate whether a hostname or ip address is a valid trap destination.
+        If validation fails, it returns an error identifying the problem that occurred.
+
+        Args:
+            data (dict): Object to create.
+            timeout:
+                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
+                in OneView, just stop waiting for its completion.
+
+        Return:
+            None if successful, else returns error message.
+
+        """
+        validation_uri = "{}/validation".format(self.URI)
+        return super(ApplianceDeviceSNMPv1TrapDestinations, self).create(data, uri=validation_uri, timeout=timeout)
+
+    def create(self, data=None, id=None, timeout=-1):
         """
         Adds the specified trap forwarding destination.
         The trap destination associated with the specified id will be created if trap destination with that id does not exists.
         The id can only be an integer greater than 0.
 
         Args:
-            resource (dict): Object to create.
+            data (dict): Object to create.
+            id: id of the resource to be created
             timeout:
                 Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
                 in OneView, just stop waiting for its completion.
 
-        Returns:
+        Return:
             dict: Created resource.
 
         """
         if not id:
             available_id = self.__get_first_available_id()
-            uri = '%s/%s' % (self.URI, str(available_id))
+            uri = '{}/{}'.format(self.URI, available_id)
         else:
-            uri = '%s/%s' % (self.URI, str(id))
-        return self._client.create(resource, uri=uri, timeout=timeout)
+            uri = '{}/{}'.format(self.URI, id)
+        return super(ApplianceDeviceSNMPv1TrapDestinations, self).create(data, uri=uri, timeout=timeout)
 
     def __findFirstMissing(self, array, start, end):
         """
         Find the smallest elements missing in a sorted array.
+
+        Args:
+            array - list if ids
+            start - starting index
+            end - ending index
 
         Returns:
             int: The smallest element missing.
@@ -88,7 +129,7 @@ class ApplianceDeviceSNMPv1TrapDestinations(object):
         Returns:
             int: The first available id
         """
-        traps = self.get_all()
+        traps = super(ApplianceDeviceSNMPv1TrapDestinations, self).get_all()
         if traps:
             used_ids = [0]
             for trap in traps:
@@ -98,87 +139,3 @@ class ApplianceDeviceSNMPv1TrapDestinations(object):
             return self.__findFirstMissing(used_ids, 0, len(used_ids) - 1)
         else:
             return 1
-
-    def get(self, id_or_uri):
-        """
-        Returns the SNMPv1 trap forwarding destination with the specified ID, if it exists.
-
-        Args:
-            id_or_uri: ID or URI of SNMPv1 trap destination.
-
-        Returns:
-            dict: Appliance SNMPv1 trap destination.
-        """
-        return self._client.get(id_or_uri)
-
-    def get_all(self, start=0, count=-1, filter='', sort=''):
-        """
-        Retrieves all SNMPv1 trap forwarding destinations.
-
-        Args:
-            start:
-                The first item to return, using 0-based indexing.
-                If not specified, the default is 0 - start with the first available item.
-            count:
-                The number of resources to return. A count of -1 requests all items.
-
-                The actual number of items in the response might differ from the requested
-                count if the sum of start and count exceeds the total number of items.
-            filter (list or str):
-                A general filter/query string to narrow the list of items returned. The
-                default is no filter; all resources are returned.
-            sort:
-                The sort order of the returned data set. By default, the sort order is based
-                on create time with the oldest entry first.
-
-        Returns:
-            list: A list of SNMPv1 Trap Destionations.
-        """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
-
-    def get_by(self, field, value):
-        """
-        Gets all SNMPv1 trap forwarding destinations that match the filter.
-        The search is case-insensitive.
-
-        Args:
-            field: field name to filter
-            value: value to filter
-
-        Returns:
-            list: A list of SNMPv1 Trap Destionations.
-        """
-        return self._client.get_by(field, value)
-
-    def delete(self, id_or_uri, timeout=-1):
-        """
-        Deletes SNMPv1 trap forwarding destination based on {Id}.
-
-        Args:
-            id_or_uri: dict object to delete
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView, just stop waiting for its completion.
-
-        Returns:
-            bool: Indicates if the resource was successfully deleted.
-
-        """
-        return self._client.delete(id_or_uri, timeout=timeout)
-
-    def update(self, resource, timeout=-1):
-        """
-        Updates the specified trap forwarding destination.
-        The trap destination associated with the specified id will be updated if a trap destination with that id already exists.
-        The id can only be an integer greater than 0.
-
-        Args:
-            resource: dict object with changes.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView, just stop waiting for its completion.
-
-        Returns:
-            dict: Updated appliance SNMPv1 trap destinations.
-        """
-        return self._client.update(resource, timeout=timeout)

--- a/hpOneView/resources/settings/appliance_device_snmp_v1_trap_destinations.py
+++ b/hpOneView/resources/settings/appliance_device_snmp_v1_trap_destinations.py
@@ -53,7 +53,6 @@ class ApplianceDeviceSNMPv1TrapDestinations(Resource):
         uri = "{0}/{1}".format(self.URI, id)
         return self._helper.do_get(uri)
 
-
     def create_validation(self, data=None, timeout=-1):
         """
         Validate whether a hostname or ip address is a valid trap destination.

--- a/tests/unit/resources/settings/test_appliance_device_snmp_v1_trap_destinations.py
+++ b/tests/unit/resources/settings/test_appliance_device_snmp_v1_trap_destinations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,74 +15,127 @@
 # limitations under the License.
 ###
 
-import unittest
+from unittest import TestCase
 
 import mock
 
 from hpOneView.connection import connection
+from hpOneView.resources.resource import Resource, ResourceHelper
 from hpOneView.resources.settings.appliance_device_snmp_v1_trap_destinations import ApplianceDeviceSNMPv1TrapDestinations
-from hpOneView.resources.resource import ResourceClient
 
 
-class ApplianceDeviceSNMPv1TrapDestinationsTest(unittest.TestCase):
+class ApplianceDeviceSNMPv1TrapDestinationsTest(TestCase):
+
     def setUp(self):
         self.host = '127.0.0.1'
         self.connection = connection(self.host)
-        self._snmp_v1_trap_dest = ApplianceDeviceSNMPv1TrapDestinations(self.connection)
+        self.__appliance_device_snmp_v1_trap_destinations = ApplianceDeviceSNMPv1TrapDestinations(self.connection)
+        self.uri = "/rest/appliance/trap-destinations"
+        self.__appliance_device_snmp_v1_trap_destinations.data = {"uri": self.uri}
 
-    @mock.patch.object(ResourceClient, 'get_all')
-    def test_get_all_called_once(self, mock_get):
-        self._snmp_v1_trap_dest.get_all()
-        mock_get.assert_called_once_with(0, -1, filter='', sort='')
+    @mock.patch.object(Resource, 'get_all')
+    def test_get_all(self, mock_get_all):
+        filter = 'name=TestName'
+        sort = 'name:ascending'
 
-    @mock.patch.object(ResourceClient, 'create')
+        self.__appliance_device_snmp_v1_trap_destinations.get_all(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
+
+    @mock.patch.object(Resource, 'get_all')
+    def test_get_all_called_once_with_default(self, mock_get_all):
+        self.__appliance_device_snmp_v1_trap_destinations.get_all()
+        mock_get_all.assert_called_once_with()
+
+    @mock.patch.object(Resource, 'get_by_uri')
+    def test_get_by_uri_called_once(self, mock_get_by_uri):
+        uri = "/rest/appliance/trap-destinations/1"
+        self.__appliance_device_snmp_v1_trap_destinations.get_by_uri(uri)
+        mock_get_by_uri.assert_called_once_with(uri)
+
+    @mock.patch.object(Resource, 'get_by')
+    def test_get_by_called_once(self, mock_get_by):
+        traps = [{'communityString': 'test', 'destination': '1.1.1.1'}, {'communityString': 'public', 'destination': '1.2.3.4'}]
+        mock_get_by.return_value = traps
+        result = self.__appliance_device_snmp_v1_trap_destinations.get_by("destination", '1.1.1.1')
+        mock_get_by.assert_called_once_with("destination", '1.1.1.1')
+        self.assertEqual(result, traps)
+
+    @mock.patch.object(Resource, 'create')
     def test_create_called_once(self, mock_create):
+        create_uri = "{}/1".format(self.uri)
+        trap_id = 1
+
         resource = {
             'destination': '1.1.1.1',
             'communityString': 'public',
             'port': 162
         }
-        trap_id = 1
-        self._snmp_v1_trap_dest.create(resource, trap_id)
-        mock_create.assert_called_once_with(resource, uri="/rest/appliance/trap-destinations/%s" % (trap_id), timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_called_once(self, mock_get):
-        self._snmp_v1_trap_dest.get('1')
+        resource_rest_call = resource.copy()
+        mock_create.return_value = {}
 
-        mock_get.assert_called_once_with('1')
+        self.__appliance_device_snmp_v1_trap_destinations.create(resource, trap_id)
+        mock_create.assert_called_once_with(resource_rest_call, uri=create_uri, timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_with_uri_called_once(self, mock_get):
-        uri = '/rest/appliance/trap-destinations/1'
-        self._snmp_v1_trap_dest.get(uri)
+    @mock.patch.object(Resource, 'get_all')
+    @mock.patch.object(Resource, 'create')
+    def test_create_called_once_with_defaults(self, mock_create, get_all):
+        create_uri = "{}/1".format(self.uri)
+        mock_create.return_value = {}
 
-        mock_get.assert_called_once_with(uri)
+        self.__appliance_device_snmp_v1_trap_destinations.create()
+        mock_create.assert_called_once_with(None, uri=create_uri, timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'get_by')
-    def test_get_by_uri_called_once(self, mock_create):
-        uri = '/rest/appliance/trap-destinations/1'
-        self._snmp_v1_trap_dest.get_by('uri', uri)
-        mock_create.assert_called_once_with('uri', uri)
-
-    @mock.patch.object(ResourceClient, 'get_by')
-    def test_get_by_destination_called_once(self, mock_create):
-        dest = '1.1.1.1'
-        self._snmp_v1_trap_dest.get_by('destination', dest)
-        mock_create.assert_called_once_with('destination', dest)
-
-    @mock.patch.object(ResourceClient, 'update')
-    def test_update_called_once(self, mock_create):
+    @mock.patch.object(Resource, 'create')
+    def test_create_validation_called_once(self, mock_create_validation):
         resource = {
-            'communityString': 'test',
-            'port': 162,
-            'uri': '/rest/appliance/trap-destinations/1'
+            'destination': '1.1.1.1',
+            'communityString': 'public',
+            'port': 162
         }
-        self._snmp_v1_trap_dest.update(resource)
-        mock_create.assert_called_once_with(resource, timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'delete')
-    def test_delete_called_once(self, mock_create):
-        id_or_uri = '/rest/appliance/trap-destinations/1'
-        self._snmp_v1_trap_dest.delete(id_or_uri)
-        mock_create.assert_called_once_with(id_or_uri, timeout=-1)
+        validation_uri = "{}/validation".format(self.uri)
+        resource_rest_call = resource.copy()
+        mock_create_validation.return_value = {}
+
+        self.__appliance_device_snmp_v1_trap_destinations.create_validation(resource, timeout=60)
+        mock_create_validation.assert_called_once_with(resource_rest_call, uri=validation_uri, timeout=60)
+
+    @mock.patch.object(Resource, 'create')
+    def test_create_validation_called_once_with_defaults(self, mock_create_validation):
+        validation_uri = "{}/validation".format(self.uri)
+        mock_create_validation.return_value = {}
+
+        self.__appliance_device_snmp_v1_trap_destinations.create_validation()
+        mock_create_validation.assert_called_once_with(None, uri=validation_uri, timeout=-1)
+
+    @mock.patch.object(ResourceHelper, 'do_get')
+    def test_get_by_id_called_once(self, mock_get_by_id):
+        uri_rest_call = "{0}/1".format(self.uri)
+        self.__appliance_device_snmp_v1_trap_destinations.get_by_id(1)
+        mock_get_by_id.assert_called_once_with(uri_rest_call)
+
+    @mock.patch.object(Resource, 'ensure_resource_data')
+    @mock.patch.object(ResourceHelper, 'update')
+    def test_update_called_once_with_default(self, mock_update, mock_ensure_client):
+        resource = {
+            "destination": "1.1.1.2",
+            "uri": self.uri
+        }
+        self.__appliance_device_snmp_v1_trap_destinations.update(resource)
+        mock_update.assert_called_once_with(resource, self.uri, False, -1, None)
+
+    @mock.patch.object(Resource, 'ensure_resource_data')
+    @mock.patch.object(ResourceHelper, 'update')
+    def test_update_called_once(self, mock_update, mock_ensure_client):
+        resource = {
+            "uri": self.uri,
+            "destination": "1.1.1.2",
+        }
+        self.__appliance_device_snmp_v1_trap_destinations.update(resource, 70)
+        mock_update.assert_called_once_with(resource, self.uri, False, 70, None)
+
+    @mock.patch.object(Resource, 'delete')
+    def test_delete_called_once(self, mock_delete):
+        self.__appliance_device_snmp_v1_trap_destinations.delete()
+        mock_delete.assert_called_once_with()

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -882,9 +882,9 @@ class OneViewClientTest(unittest.TestCase):
         self.assertIsInstance(self._oneview.appliance_device_snmp_v1_trap_destinations,
                               ApplianceDeviceSNMPv1TrapDestinations)
 
-    def test_lazy_loading_appliance_device_device_snmp_v1_trap_destinations(self):
+    def test_appliance_device_device_snmp_v1_trap_destinations_client(self):
         appliance_device_snmp_v1_trap_destinations = self._oneview.appliance_device_snmp_v1_trap_destinations
-        self.assertEqual(appliance_device_snmp_v1_trap_destinations, self._oneview.appliance_device_snmp_v1_trap_destinations)
+        self.assertNotEqual(appliance_device_snmp_v1_trap_destinations, self._oneview.appliance_device_snmp_v1_trap_destinations)
 
     def test_appliance_device_device_snmp_v3_trap_destinations_has_right_type(self):
         self.assertIsInstance(self._oneview.appliance_device_snmp_v3_trap_destinations,


### PR DESCRIPTION
### Description
Refactored Appliance SNMPv1 trap destinations resource for API 800, 1000, 1200

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
