### PR TITLE
Handled exception in get_by_alias_name method of certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 5.1.1 (Unreleased)
 
-Bugfixes and corrections.
+#### Bug fixes & Enhancements
+- #34 Handle exception of get_by_aliasname method in certificates_server resource and return resource object
 
 # 5.1.0
 #### Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 5.1.1 (Unreleased)
+
+Bugfixes and corrections.
+
 # 5.1.0
 #### Notes
 Extends support of the SDK to OneView REST API version 800, 1000 and 1200.

--- a/examples/certificates_server.py
+++ b/examples/certificates_server.py
@@ -51,21 +51,22 @@ certificate_server = oneview_client.certificates_server
 # Fetch server certificate of remote server
 print("\nGet server certificate of remote server by ip address")
 remote_server_cert = certificate_server.get_remote(remote_server_options['name'])
-ca_certificate = remote_server_cert['certificateDetails'][0]['base64Data']
+ca_certificate = remote_server_cert.data['certificateDetails'][0]['base64Data']
 print(ca_certificate)
-
-# Add a server certificate with the options provided
-options['certificateDetails'][0]['base64Data'] = ca_certificate
-options['certificateDetails'][0]['type'] = remote_server_cert['certificateDetails'][0]['type']
-server_certificate = certificate_server.create(data=options)
-print("\nAdded a server certificate with aliasName: {}.\n  uri = {}".format(
-      server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
 
 # Fetch certificate by alias name
 print("\nGet server certificate by alias name")
-server_cert_by_alias = certificate_server.get_by_aliasName("vcenter")
-print("\nFound server certificate by aliasName: {}.\n  uri = {}".format(
-      server_cert_by_alias['certificateDetails'][0]['aliasName'], server_cert_by_alias['uri']))
+server_certificate = certificate_server.get_by_alias_name("vcenter")
+if server_certificate:
+    print("\nFound server certificate by aliasName: {}.\n  uri = {}".format(
+      server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
+else:
+# Add a server certificate with the options provided
+    options['certificateDetails'][0]['base64Data'] = ca_certificate
+    options['certificateDetails'][0]['type'] = remote_server_cert.data['certificateDetails'][0]['type']
+    server_certificate = certificate_server.create(data=options)
+    print("\nAdded a server certificate with aliasName: {}.\n  uri = {}".format(
+          server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
 
 # Get by uri
 print("\nGet a server certificate by uri")

--- a/examples/certificates_server.py
+++ b/examples/certificates_server.py
@@ -59,9 +59,9 @@ print("\nGet server certificate by alias name")
 server_certificate = certificate_server.get_by_alias_name("vcenter")
 if server_certificate:
     print("\nFound server certificate by aliasName: {}.\n  uri = {}".format(
-      server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
+        server_certificate.data['certificateDetails'][0]['aliasName'], server_certificate.data['uri']))
 else:
-# Add a server certificate with the options provided
+    # Add a server certificate with the options provided
     options['certificateDetails'][0]['base64Data'] = ca_certificate
     options['certificateDetails'][0]['type'] = remote_server_cert.data['certificateDetails'][0]['type']
     server_certificate = certificate_server.create(data=options)

--- a/hpOneView/resources/security/certificates_server.py
+++ b/hpOneView/resources/security/certificates_server.py
@@ -25,6 +25,7 @@ standard_library.install_aliases()
 
 
 from hpOneView.resources.resource import Resource
+from hpOneView.exceptions import HPOneViewException
 
 
 class CertificatesServer(Resource):
@@ -73,9 +74,9 @@ class CertificatesServer(Resource):
              dict: Certificate chain of remote server
         """
         uri = "{0}/https/remote/{1}".format(self.URI, remote_address)
-        return self._helper.do_get(uri)
+        return super(CertificatesServer, self).get_by_uri(uri=uri)
 
-    def get_by_aliasName(self, alias_name):
+    def get_by_alias_name(self, alias_name):
         """
         Retrieves the device or server certificate, already trusted in the appliance,
         with the specified aliasName.
@@ -87,4 +88,8 @@ class CertificatesServer(Resource):
             dict: Certificate of trusted appliance
         """
         uri = "{0}/servers/{1}".format(self.URI, alias_name)
-        return self._helper.do_get(uri)
+        try:
+            response = super(CertificatesServer, self).get_by_uri(uri=uri)
+        except HPOneViewException:
+            response = None
+        return response

--- a/tests/unit/resources/security/test_certificates_server.py
+++ b/tests/unit/resources/security/test_certificates_server.py
@@ -22,6 +22,7 @@ import mock
 from hpOneView.connection import connection
 from hpOneView.resources.security.certificates_server import CertificatesServer
 from hpOneView.resources.resource import Resource, ResourceHelper
+from hpOneView.exceptions import HPOneViewException
 
 
 class CertificatesServerTest(TestCase):
@@ -72,6 +73,11 @@ class CertificatesServerTest(TestCase):
         uri_rest_call = "{0}/{1}".format(self.uri, "test1")
         self._certificate_server.get_by_alias_name("test1")
         mock_get_by_aliasname.assert_called_once_with(uri=uri_rest_call)
+
+    @mock.patch.object(Resource, 'get_by_uri')
+    def test_get_by_aliasName_when_not_found(self, mock_get_by):
+        mock_get_by.side_effect = HPOneViewException("not found")
+        self.assertEqual(self._certificate_server.get_by_alias_name("test1"), None)
 
     @mock.patch.object(Resource, 'ensure_resource_data')
     @mock.patch.object(ResourceHelper, 'update')

--- a/tests/unit/resources/security/test_certificates_server.py
+++ b/tests/unit/resources/security/test_certificates_server.py
@@ -59,19 +59,19 @@ class CertificatesServerTest(TestCase):
         self._certificate_server.create(resource)
         mock_create.assert_called_once_with(resource_rest_call, uri=self.uri, timeout=-1)
 
-    @mock.patch.object(ResourceHelper, 'do_get')
+    @mock.patch.object(Resource, 'get_by_uri')
     def test_get_remote_server_called_once(self, mock_get_remote):
         remote_server = "1.2.3.4"
         uri_rest_call = "/rest/certificates/https/remote/{}".format(remote_server)
 
         self._certificate_server.get_remote(remote_server)
-        mock_get_remote.assert_called_once_with(uri_rest_call)
+        mock_get_remote.assert_called_once_with(uri=uri_rest_call)
 
-    @mock.patch.object(ResourceHelper, 'do_get')
-    def test_get_by_aliasName_called_once(self, mock_get_by_aliasName):
+    @mock.patch.object(Resource, 'get_by_uri')
+    def test_get_by_aliasName_called_once(self, mock_get_by_aliasname):
         uri_rest_call = "{0}/{1}".format(self.uri, "test1")
-        self._certificate_server.get_by_aliasName("test1")
-        mock_get_by_aliasName.assert_called_once_with(uri_rest_call)
+        self._certificate_server.get_by_alias_name("test1")
+        mock_get_by_aliasname.assert_called_once_with(uri=uri_rest_call)
 
     @mock.patch.object(Resource, 'ensure_resource_data')
     @mock.patch.object(ResourceHelper, 'update')


### PR DESCRIPTION
### Description
Handled exception in get_by_alias_name method of certificate and renamed method name to follow naming convention

### Issues Resolved
#34 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [ ] Changes are documented in the CHANGELOG.
