### PR TITLE
Added support for OV 5.2 for cluster profile resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.2.0 (unreleased)
+Extends support of the SDK to OneView REST API version 1600 (OneView v5.20).
+
 # 5.1.1
 
 #### Bug fixes & Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 5.2.0 (unreleased)
+#### Notes
 Extends support of the SDK to OneView REST API version 1600 (OneView v5.20).
+
+#### Features supported with the current release
+- Certificates Server
+- Hypervisor Cluster Profiles
+- Hypervisor Managers
 
 # 5.1.1
 

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -18,19 +18,19 @@
 
 ## HPE OneView
 
-| Endpoints                                                                               | Verb     |  V800                 | V1000               | V1200
-| --------------------------------------------------------------------------------------- | -------- |  :------------------: | :------------------:| :------------------: |
+| Endpoints                                                                               | Verb     |  V800                 | V1000               | V1200                | V1600               |
+| --------------------------------------------------------------------------------------- | -------- |  :------------------: | :------------------:| :------------------: | :-----------------: |
 |     **Connection Templates**
 |<sub>/rest/connection-templates</sub>                                                    |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/connection-templates/defaultConnectionTemplate</sub>                          |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/connection-templates/{id}</sub>                                               |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/connection-templates/{id}</sub>                                               |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Certificates Server**
-|<sub>/rest/certificates/servers</sub>                                                    |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/certificates/https/remote/example.com</sub>                                   |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/certificates/servers</sub>                                                    |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/certificates/https/remote/example.com</sub>                                   |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/certificates/servers/{aliasName}</sub>                                        |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |     **Enclosure Groups**
 |<sub>/rest/enclosure-groups</sub>                                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/enclosure-groups</sub>                                                        | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -80,19 +80,19 @@
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |     **Hypervisor Cluster Profiles**
-|<sub>/rest/hypervisor-cluster-profiles</sub>                                             |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-cluster-profiles</sub>                                             |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-cluster-profiles/{id}</sub>                                        |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-cluster-profiles/{id}</sub>                                        |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-cluster-profiles/{id}</sub>                                        |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-cluster-profiles/virtualswitch-layout</sub>                        |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-cluster-profiles/{id}/compliance-preview</sub>                     |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles</sub>                                             |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles</sub>                                             |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles/{id}</sub>                                        |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles/{id}</sub>                                        |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles/{id}</sub>                                        |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles/virtualswitch-layout</sub>                        |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-cluster-profiles/{id}/compliance-preview</sub>                     |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |     **Hypervisor Managers**
-|<sub>/rest/hypervisor-managers</sub>                                                     |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-managers</sub>                                                     |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-managers/{id}</sub>                                                |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-managers/{id}</sub>                                                |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/hypervisor-managers/{id}</sub>                                                |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/hypervisor-managers</sub>                                                     |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-managers</sub>                                                     |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-managers/{id}</sub>                                                |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-managers/{id}</sub>                                                |PUT       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/hypervisor-managers/{id}</sub>                                                |DELETE    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |     **Interconnects**
 |<sub>/rest/interconnects</sub>                                                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/interconnects/{id}</sub>                                                      | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/hypervisor_cluster_profiles.py
+++ b/examples/hypervisor_cluster_profiles.py
@@ -29,7 +29,7 @@ config = {
 }
 
 options = {
-    "type": "HypervisorClusterProfileV3",
+    "name": "Test_cluster_profile",
     "description": "test cluster",
     "hypervisorType": "Vmware",
     "hypervisorClusterSettings": {
@@ -56,7 +56,6 @@ options = {
             "configurePortGroups": True
         }
     },
-    "name": "Test_cluster_profile",
     "mgmtIpSettingsOverride": None,
     "hypervisorManagerUri": "172.18.13.11",
     "path": "DC1",
@@ -148,5 +147,5 @@ profile_compliance = hypervisor_cluster_profile.get_compliance_preview()
 print("   - Compliance preview: '{}'".format(profile_compliance))
 
 # Delete the created hypervisor cluster profile
-hypervisor_cluster_profile.delete()
+hypervisor_cluster_profile.delete(softDelete=True, force=True)
 print("\nSuccessfully deleted hypervisor cluster profile")

--- a/examples/hypervisor_cluster_profiles.py
+++ b/examples/hypervisor_cluster_profiles.py
@@ -147,5 +147,5 @@ profile_compliance = hypervisor_cluster_profile.get_compliance_preview()
 print("   - Compliance preview: '{}'".format(profile_compliance))
 
 # Delete the created hypervisor cluster profile
-hypervisor_cluster_profile.delete(softDelete=True, force=True)
+hypervisor_cluster_profile.delete(soft_delete=True, force=True)
 print("\nSuccessfully deleted hypervisor cluster profile")

--- a/examples/hypervisor_managers.py
+++ b/examples/hypervisor_managers.py
@@ -29,13 +29,11 @@ config = {
 }
 
 options = {
-    "type": "HypervisorManagerV2",
     "name": "172.18.13.11",
     "displayName": "vcenter",
     "hypervisorType": "Vmware",
     "username": "dcs",
     "password": "dcs",
-    "initialScopeUris": []
 }
 
 # Try load config from a file (if there is a config file)

--- a/hpOneView/resources/hypervisors/hypervisor_cluster_profiles.py
+++ b/hpOneView/resources/hypervisors/hypervisor_cluster_profiles.py
@@ -36,7 +36,8 @@ class HypervisorClusterProfiles(Resource):
     DEFAULT_VALUES = {
         '800': {"type": "HypervisorClusterProfileV3"},
         '1000': {"type": "HypervisorClusterProfileV3"},
-        '1200': {"type": "HypervisorClusterProfileV3"}
+        '1200': {"type": "HypervisorClusterProfileV3"},
+        '1600': {"type": "HypervisorClusterProfileV3"}
     }
 
     def __init__(self, connection, data=None):
@@ -102,3 +103,26 @@ class HypervisorClusterProfiles(Resource):
         """
         compliance_uri = "{0}/compliance-preview".format(self.data["uri"])
         return self._helper.do_get(compliance_uri)
+
+    def delete(self, timeout=-1, softDelete=False, force=False):
+        """
+        Deletes a hypervisor cluster profile object from the appliance based on Hypervisor Cluster Profile UUID
+
+        Args:
+            force:
+                If set to true, the operation completes despite any probles with network
+                connectivity or errors on the resource itself. Default is false.
+            softDelete:
+                If set to true, the hypervisor cluster profile and its hypervisor profiles
+                are removed from appliance only. If set to false, the associated cluster and
+                hosts are also removed in the hypervisor manager.
+
+        Return:
+            Boolean value. True for success and False for failure.
+        """
+        uri = "{}?softDelete={}".format(self.data['uri'], softDelete)
+
+        if force:
+            uri += '&force=True'
+
+        return self._helper.delete(uri, timeout=timeout)

--- a/hpOneView/resources/hypervisors/hypervisor_cluster_profiles.py
+++ b/hpOneView/resources/hypervisors/hypervisor_cluster_profiles.py
@@ -104,7 +104,7 @@ class HypervisorClusterProfiles(Resource):
         compliance_uri = "{0}/compliance-preview".format(self.data["uri"])
         return self._helper.do_get(compliance_uri)
 
-    def delete(self, timeout=-1, softDelete=False, force=False):
+    def delete(self, timeout=-1, soft_delete=False, force=False):
         """
         Deletes a hypervisor cluster profile object from the appliance based on Hypervisor Cluster Profile UUID
 
@@ -112,7 +112,7 @@ class HypervisorClusterProfiles(Resource):
             force:
                 If set to true, the operation completes despite any probles with network
                 connectivity or errors on the resource itself. Default is false.
-            softDelete:
+            soft_delete:
                 If set to true, the hypervisor cluster profile and its hypervisor profiles
                 are removed from appliance only. If set to false, the associated cluster and
                 hosts are also removed in the hypervisor manager.
@@ -120,7 +120,7 @@ class HypervisorClusterProfiles(Resource):
         Return:
             Boolean value. True for success and False for failure.
         """
-        uri = "{}?softDelete={}".format(self.data['uri'], softDelete)
+        uri = "{}?softDelete={}".format(self.data['uri'], soft_delete)
 
         if force:
             uri += '&force=True'

--- a/hpOneView/resources/hypervisors/hypervisor_managers.py
+++ b/hpOneView/resources/hypervisors/hypervisor_managers.py
@@ -37,7 +37,8 @@ class HypervisorManagers(Resource):
     DEFAULT_VALUES = {
         '800': {"type": "HypervisorManagerV2"},
         '1000': {"type": "HypervisorManagerV2"},
-        '1200': {"type": "HypervisorManagerV2"}
+        '1200': {"type": "HypervisorManagerV2"},
+        '1600': {"type": "HypervisorManagerV2"}
     }
 
     def __init__(self, connection, data=None):

--- a/hpOneView/resources/security/certificates_server.py
+++ b/hpOneView/resources/security/certificates_server.py
@@ -41,7 +41,8 @@ class CertificatesServer(Resource):
     DEFAULT_VALUES = {
         '800': {"type": "CertificateInfoV2"},
         '1000': {"type": "CertificateInfoV2"},
-        '1200': {"type": "CertificateInfoV2"}
+        '1200': {"type": "CertificateInfoV2"},
+        '1600': {"type": "CertificateInfoV2"}
     }
 
     def __init__(self, connection, data=None):

--- a/tests/unit/resources/hypervisors/test_hypervisor_cluster_profiles.py
+++ b/tests/unit/resources/hypervisors/test_hypervisor_cluster_profiles.py
@@ -160,10 +160,12 @@ class HypervisorClusterProfilesTest(TestCase):
 
     @mock.patch.object(ResourceHelper, 'delete')
     def test_delete_called_once(self, mock_delete):
+        delete_uri = "{}?softDelete=False".format(self.uri)
         self._hypervisor_cluster_profiles.delete(force=False)
-        mock_delete.assert_called_once_with(self.uri, custom_headers=None, force=False, timeout=-1)
+        mock_delete.assert_called_once_with(delete_uri, timeout=-1)
 
     @mock.patch.object(ResourceHelper, 'delete')
     def test_delete_called_once_with_force(self, mock_delete):
+        delete_uri = "{}?softDelete=False&force=True".format(self.uri)
         self._hypervisor_cluster_profiles.delete(force=True)
-        mock_delete.assert_called_once_with(self.uri, custom_headers=None, force=True, timeout=-1)
+        mock_delete.assert_called_once_with(delete_uri, timeout=-1)


### PR DESCRIPTION
### Description
Added support for OV 5.2 for cluster profile resources

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
