### PR TITLE
Adding Scopes for API 800, 1000, 1200 and 1600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Extends support of the SDK to OneView REST API version 1600 (OneView v5.20).
 - Logical Interconnects
 - Logical Interconnect Groups
 - Network set
+- Scopes
 - Server Hardware
 - Server Hardware Types
 - Server Profiles

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -215,7 +215,13 @@
 |<sub>/rest/sas-logical-interconnects/{id}/compliance</sub>                               | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/sas-logical-interconnects/{lsId}/configuration</sub>                          | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/sas-logical-interconnects/{id}/replaceDriveEnclosure</sub>                    | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|     **Server Hardware**
+|     **Scopes**
+|<sub>/rest/scopes</sub>                                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes</sub>                                                                  | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/{id}</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/{id}</sub>                                                             | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/{id}</sub>                                                             | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+     **Server Hardware**
 |<sub>/rest/server-hardware</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware</sub>                                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -225,7 +225,7 @@
 |<sub>/rest/scopes/resources</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/scopes/resources</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/scopes/resources</sub>                                                        | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-     **Server Hardware**
+|     **Server Hardware**
 |<sub>/rest/server-hardware</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware</sub>                                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}</sub>                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -241,11 +241,11 @@
 |<sub>/rest/server-hardware/{id}/refreshState</sub>                                       | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}/remoteConsoleUrl</sub>                                   | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware/{id}/utilization</sub>                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}                                                          | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/*/firmware                                                    | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/{id}/firmware                                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|<sub>/rest/server-hardware/discovery                                                     | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|     **Server Hardware Types**
+|<sub>/rest/server-hardware/{id}</sub>                                                    | PATCH    |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/*/firmware</sub>                                              | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/{id}/firmware</sub>                                           | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/server-hardware/discovery</sub>                                               | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|       **Server Hardware Types**
 |<sub>/rest/server-hardware-types</sub>                                                   | GET      |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware-types/{id}</sub>                                              | GET      |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware-types/{id}</sub>                                              | PUT      |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -259,7 +259,7 @@
 |<sub>/rest/server-profile-templates/{id}/new-profile</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/server-profile-templates/{id}/transformation</sub>                            | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/server-profile-templates/available-networks</sub>                             | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
-|     **Server Profiles**
+|        **Server Profiles**
 |<sub>/rest/server-profiles</sub>                                                         | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-profiles</sub>                                                         | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-profiles</sub>                                                         | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
@@ -277,7 +277,7 @@
 |<sub>/rest/server-profiles/{id}/new-profile-template</sub>                               | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :heavy_minus_sign:   |
 |<sub>/rest/server-profiles/{id}/messages</sub>                                           | GET      | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |
 |<sub>/rest/server-profiles/{id}/transformation</sub>                                     | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
-|     **Storage Pools**
+|    **Storage Pools**
 |<sub>/rest/storage-pools</sub>                                                           | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark:|:white_check_mark:   |
 |<sub>/rest/storage-pools</sub>                                                           | POST     | :heavy_minus_sign:   | :heavy_minus_sign: | :heavy_minus_sign:| :heavy_minus_sign:
 |<sub>/rest/storage-pools/reachable-storage-pools</sub>                                   | GET      | :white_check_mark:   | :white_check_mark: | :white_check_mark:|:white_check_mark:   |

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -221,6 +221,10 @@
 |<sub>/rest/scopes/{id}</sub>                                                             | POST     | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/scopes/{id}</sub>                                                             | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/scopes/{id}</sub>                                                             | DELETE   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/{id}                                                                   | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/resources</sub>                                                        | GET      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/resources</sub>                                                        | PUT      | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
+|<sub>/rest/scopes/resources</sub>                                                        | PATCH    | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
      **Server Hardware**
 |<sub>/rest/server-hardware</sub>                                                         | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |
 |<sub>/rest/server-hardware</sub>                                                         | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |

--- a/examples/scopes.py
+++ b/examples/scopes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,8 +30,9 @@ config = {
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
-
 oneview_client = OneViewClient(config)
+scopes = oneview_client.scopes
+ethernet_networks = oneview_client.ethernet_networks
 
 default_options = {
     "ethernetNetworkType": "Tagged",
@@ -42,9 +43,9 @@ default_options = {
 }
 
 # Set the URI of existent resources to be added/removed to/from the scope
-resource_uri_1 = oneview_client.ethernet_networks.get_by('name', 'Scope OneView SDK Ethernet 1')[0]['uri']
-resource_uri_2 = oneview_client.ethernet_networks.get_by('name', 'Scope OneView SDK Ethernet 2')[0]['uri']
-resource_uri_3 = oneview_client.ethernet_networks.get_by('name', 'Scope OneView SDK Ethernet 3')[0]['uri']
+resource_uri_1 = ethernet_networks.get_by('name', 'TestNetwork_1')[0]['uri']
+resource_uri_2 = ethernet_networks.get_by('name', 'TestNetwork_2')[0]['uri']
+resource_uri_3 = ethernet_networks.get_by('name', 'TestNetwork_3')[0]['uri']
 
 # Create a scope
 print("\n## Create the scope")
@@ -52,27 +53,27 @@ options = {
     "name": "SampleScope",
     "description": "Sample Scope description"
 }
-scope = oneview_client.scopes.create(options)
+scope = scopes.create(options)
 pprint(scope)
 
 # Update the name of the scope
 print("\n## Update the scope")
 scope['name'] = "SampleScopeRenamed"
-scope = oneview_client.scopes.update(scope)
+scope = scopes.update(scope)
 pprint(scope)
 
 # Find the recently created scope by name
-scope_by_name = oneview_client.scopes.get_by_name('SampleScopeRenamed')
+scope_by_name = scopes.get_by_name('SampleScopeRenamed')
 print("\n## Found scope by name: '{name}'.\n  uri = '{uri}'".format(**scope_by_name))
 
 # Find the recently created scope by URI
-scope_by_uri = oneview_client.scopes.get(scope['uri'])
+scope_by_uri = scopes.get(scope['uri'])
 print("\n## Found scope by URI: '{uri}'.\n  name = '{name}'".format(**scope_by_uri))
 
 # Get all scopes
 print("\n## Get all Scopes")
-scopes = oneview_client.scopes.get_all()
-pprint(scopes)
+all_scopes = scopes.get_all()
+pprint(all_scopes)
 
 # Update the scope resource assignments (Available only in API300)
 try:
@@ -80,7 +81,7 @@ try:
     options = {
         "addedResourceUris": [resource_uri_1, resource_uri_2]
     }
-    oneview_client.scopes.update_resource_assignments(scope['uri'], options)
+    scopes.update_resource_assignments(scope['uri'], options)
     print("  Done.")
 
     print("\n## Update the scope resource assignments, adding one resource and removing another previously added")
@@ -88,7 +89,7 @@ try:
         "removedResourceUris": [resource_uri_1],
         "addedResourceUris": [resource_uri_3]
     }
-    oneview_client.scopes.update_resource_assignments(scope['uri'], options)
+    scopes.update_resource_assignments(scope['uri'], options)
     print("  Done.")
 except HPOneViewException as e:
     print(e.msg)
@@ -97,15 +98,15 @@ except HPOneViewException as e:
 try:
     print("\n## Patch the scope adding two resource uris")
     resource_list = [resource_uri_1, resource_uri_2]
-    edited_scope = oneview_client.scopes.patch(scope['uri'], 'replace', '/addedResourceUris', resource_list)
+    edited_scope = scopes.patch(scope['uri'], 'replace', '/addedResourceUris', resource_list)
     pprint(edited_scope)
 
     print("\n## Patch the scope removing the two previously added resource uris")
-    edited_scope = oneview_client.scopes.patch(scope['uri'], 'replace', '/removedResourceUris', resource_list)
+    edited_scope = scopes.patch(scope['uri'], 'replace', '/removedResourceUris', resource_list)
     pprint(edited_scope)
 except HPOneViewException as e:
     print(e.msg)
 
 # Delete the scope
-oneview_client.scopes.delete(scope)
+scopes.delete(scope)
 print("\n## Scope deleted successfully.")

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -399,9 +399,7 @@ class OneViewClient(object):
         Returns:
             Scopes:
         """
-        if not self.__scopes:
-            self.__scopes = Scopes(self.__connection)
-        return self.__scopes
+        return Scopes(self.__connection)
 
     @property
     def datacenters(self):

--- a/hpOneView/resources/settings/scopes.py
+++ b/hpOneView/resources/settings/scopes.py
@@ -97,7 +97,7 @@ class Scopes(Resource, ResourcePatchMixin):
 
 
     def delete(self, resource, timeout=-1):
-       """
+        """
         Deletes a Scope.
 
         Args:
@@ -110,6 +110,7 @@ class Scopes(Resource, ResourcePatchMixin):
             bool: Indicates if the resource was successfully deleted.
 
         """
+
         if type(resource) is dict:
             headers = {'If-Match': resource.get('eTag', '*')}
         else:

--- a/hpOneView/resources/settings/scopes.py
+++ b/hpOneView/resources/settings/scopes.py
@@ -92,7 +92,7 @@ class Scopes(Resource, ResourcePatchMixin):
 
         """
         headers = {'If-Match': resource.get('eTag', '*')}
-        return super(Scopes, self).update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES,custom_headers=headers)
+        return super(Scopes, self).update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES, custom_headers=headers)
 
     def delete(self, resource, timeout=-1):
         """

--- a/hpOneView/resources/settings/scopes.py
+++ b/hpOneView/resources/settings/scopes.py
@@ -92,7 +92,7 @@ class Scopes(Resource, ResourcePatchMixin):
 
         """
         headers = {'If-Match': resource.get('eTag', '*')}
-        return super(Scopes, self).update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES, custom_headers=headers)
+        return super(Scopes, self).update(resource, timeout=timeout, custom_headers=headers)
 
     def delete(self, resource, timeout=-1):
         """

--- a/hpOneView/resources/settings/scopes.py
+++ b/hpOneView/resources/settings/scopes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ class Scopes(Resource, ResourcePatchMixin):
             list: A list of scopes.
         """
         return self._helper.get_all(start, count, sort=sort, query=query, view=view)
-    
+
     def update(self, resource, timeout=-1):
         """
         Updates a scope.
@@ -92,9 +92,7 @@ class Scopes(Resource, ResourcePatchMixin):
 
         """
         headers = {'If-Match': resource.get('eTag', '*')}
-        return super(Scopes, self).update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES,
-                                   custom_headers=headers)
-
+        return super(Scopes, self).update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES,custom_headers=headers)
 
     def delete(self, resource, timeout=-1):
         """
@@ -117,7 +115,7 @@ class Scopes(Resource, ResourcePatchMixin):
             headers = {'If-Match': '*'}
         return super(Scopes, self).delete(resource, timeout=timeout, custom_headers=headers)
 
-    #This function will work till API version 300
+    # This function will work till API version 300
     def update_resource_assignments(self, id_or_uri, resource_assignments, timeout=-1):
         """
         Modifies scope membership by adding or removing resource assignments.

--- a/tests/unit/resources/settings/test_scopes.py
+++ b/tests/unit/resources/settings/test_scopes.py
@@ -52,7 +52,6 @@ class ScopesTest(TestCase):
 
         headers = {'If-Match': '*'}
         mock_update.assert_called_once_with(data_rest_call, timeout=60,
-                                            default_values=self.resource.DEFAULT_VALUES,
                                             custom_headers=headers)
 
     @mock.patch.object(Resource, 'update')
@@ -62,8 +61,7 @@ class ScopesTest(TestCase):
         self.resource.update(data, -1)
 
         headers = {'If-Match': '2016-11-03T18:41:10.751Z/2016-11-03T18:41:10.751Z'}
-        mock_update.assert_called_once_with(mock.ANY, timeout=mock.ANY, default_values=mock.ANY,
-                                            custom_headers=headers)
+        mock_update.assert_called_once_with(mock.ANY, timeout=mock.ANY, custom_headers=headers)
 
     @mock.patch.object(Resource, 'delete')
     def test_delete_called_once(self, mock_delete):

--- a/tests/unit/resources/settings/test_scopes.py
+++ b/tests/unit/resources/settings/test_scopes.py
@@ -31,7 +31,6 @@ class ScopesTest(TestCase):
         oneview_connection = connection(self.DEFAULT_HOST)
         self.resource = Scopes(oneview_connection)
 
-
     @mock.patch.object(ResourceHelper, 'get_all')
     def test_get_all(self, mock_get_all):
         sort = 'name:ascending'
@@ -40,7 +39,6 @@ class ScopesTest(TestCase):
 
         self.resource.get_all(2, 500, sort, query, view)
         mock_get_all.assert_called_once_with(2, 500, sort=sort, query=query, view=view)
-
 
     @mock.patch.object(Resource, 'update')
     def test_update_called_once(self, mock_update):
@@ -98,4 +96,3 @@ class ScopesTest(TestCase):
             '/rest/scopes/11c466d1-0ade-4aae-8317-2fb20b6ef3f2/resource-assignments',
             information.copy(),
             timeout=-1)
-

--- a/tests/unit/resources/settings/test_scopes.py
+++ b/tests/unit/resources/settings/test_scopes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ from unittest import TestCase
 import mock
 
 from hpOneView.connection import connection
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourcePatchMixin
 from hpOneView.resources.settings.scopes import Scopes
 
 
@@ -31,7 +31,7 @@ class ScopesTest(TestCase):
         oneview_connection = connection(self.DEFAULT_HOST)
         self.resource = Scopes(oneview_connection)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(Resource, 'do_get')
     def test_get_all(self, mock_get_all):
         sort = 'name:ascending'
         query = 'name eq "TestName"'
@@ -40,7 +40,7 @@ class ScopesTest(TestCase):
         self.resource.get_all(2, 500, sort, query, view)
         mock_get_all.assert_called_once_with(2, 500, sort=sort, query=query, view=view)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(Resource, 'do_get')
     def test_get_by_name_should_return_scope_when_found(self, mock_get_all):
         mock_get_all.return_value = [
             {"name": "SampleScope1", "uri": "/rest/scopes/1"},
@@ -51,7 +51,7 @@ class ScopesTest(TestCase):
 
         self.assertEqual(scope, expected_result)
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(Resource, 'do_get')
     def test_get_by_name_should_return_null_when_not_found(self, mock_get_all):
         mock_get_all.return_value = [
             {"name": "SampleScope1", "uri": "/rest/scopes/1"},
@@ -61,31 +61,8 @@ class ScopesTest(TestCase):
 
         self.assertIsNone(scope)
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_called_once(self, mock_get):
-        self.resource.get('3518be0e-17c1-4189-8f81-83f3724f6155')
 
-        mock_get.assert_called_once_with('3518be0e-17c1-4189-8f81-83f3724f6155')
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_with_uri_called_once(self, mock_get):
-        uri = '/rest/scopes/3518be0e-17c1-4189-8f81-83f3724f6155'
-        self.resource.get(uri)
-
-        mock_get.assert_called_once_with(uri)
-
-    @mock.patch.object(ResourceClient, 'create')
-    def test_create_called_once(self, mock_create):
-        data = {
-            'name': 'Name of the Scope'
-        }
-        data_rest_call = data.copy()
-
-        self.resource.create(data, 30)
-        mock_create.assert_called_once_with(data_rest_call, timeout=30,
-                                            default_values=self.resource.DEFAULT_VALUES)
-
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(Resource, 'update')
     def test_update_called_once(self, mock_update):
         data = {
             'name': 'Name of the Scope',
@@ -100,7 +77,7 @@ class ScopesTest(TestCase):
                                             default_values=self.resource.DEFAULT_VALUES,
                                             custom_headers=headers)
 
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(Resource, 'update')
     def test_update_should_verify_if_match_etag_when_provided(self, mock_update):
         data = {'eTag': '2016-11-03T18:41:10.751Z/2016-11-03T18:41:10.751Z'}
 
@@ -110,14 +87,14 @@ class ScopesTest(TestCase):
         mock_update.assert_called_once_with(mock.ANY, timeout=mock.ANY, default_values=mock.ANY,
                                             custom_headers=headers)
 
-    @mock.patch.object(ResourceClient, 'delete')
+    @mock.patch.object(Resource, 'delete')
     def test_delete_called_once(self, mock_delete):
         id = 'ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self.resource.delete(id, timeout=-1)
 
         mock_delete.assert_called_once_with(id, timeout=-1, custom_headers={'If-Match': '*'})
 
-    @mock.patch.object(ResourceClient, 'delete')
+    @mock.patch.object(Resource, 'delete')
     def test_delete_should_verify_if_match_etag_when_provided(self, mock_delete):
         data = {'uri': 'a_uri',
                 'eTag': '2016-11-03T18:41:10.751Z/2016-11-03T18:41:10.751Z'}
@@ -127,7 +104,7 @@ class ScopesTest(TestCase):
         headers = {'If-Match': '2016-11-03T18:41:10.751Z/2016-11-03T18:41:10.751Z'}
         mock_delete.assert_called_once_with(mock.ANY, timeout=mock.ANY, custom_headers=headers)
 
-    @mock.patch.object(ResourceClient, 'patch_request')
+    @mock.patch.object(ResourcePatchMixin, 'patch_request')
     def test_update_resource_assignments_called_once(self, mock_patch_request):
         uri = '/rest/scopes/11c466d1-0ade-4aae-8317-2fb20b6ef3f2'
 
@@ -143,7 +120,7 @@ class ScopesTest(TestCase):
             custom_headers={'Content-Type': 'application/json'},
             timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'patch')
+    @mock.patch.object(ResourcePatchMixin, 'patch')
     def test_patch_called_once(self, mock_patch):
         uri = '/rest/scopes/main-scope'
 

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -47,7 +47,6 @@ from hpOneView.resources.networking.sas_logical_interconnect_groups import SasLo
 from hpOneView.resources.networking.sas_logical_interconnects import SasLogicalInterconnects
 from hpOneView.resources.networking.sas_interconnect_types import SasInterconnectTypes
 from hpOneView.resources.facilities.datacenters import Datacenters
-from hpOneView.resources.servers.enclosures import Enclosures
 from hpOneView.resources.servers.server_profile_templates import ServerProfileTemplate
 from hpOneView.resources.servers.server_profiles import ServerProfiles
 from hpOneView.resources.servers.id_pools import IdPools

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -47,6 +47,7 @@ from hpOneView.resources.networking.sas_logical_interconnect_groups import SasLo
 from hpOneView.resources.networking.sas_logical_interconnects import SasLogicalInterconnects
 from hpOneView.resources.networking.sas_interconnect_types import SasInterconnectTypes
 from hpOneView.resources.facilities.datacenters import Datacenters
+from hpOneView.resources.servers.enclosures import Enclosures
 from hpOneView.resources.servers.server_profile_templates import ServerProfileTemplate
 from hpOneView.resources.servers.server_profiles import ServerProfiles
 from hpOneView.resources.servers.id_pools import IdPools
@@ -545,6 +546,10 @@ class OneViewClientTest(unittest.TestCase):
     def test_logical_enclosures(self):
         logical_enclosures = self._oneview.logical_enclosures
         self.assertNotEqual(logical_enclosures, self._oneview.logical_enclosures)
+
+    def test_enclosures(self):
+        enclosures = self._oneview.enclosures
+        self.assertNotEqual(enclosures, self._oneview.enclosures)
 
     def test_should_return_new_interconnect_types_obj(self):
         self.assertNotEqual(self._oneview.interconnect_types, self._oneview.interconnect_types)

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -714,7 +714,7 @@ class OneViewClientTest(unittest.TestCase):
 
     def test_lazy_loading_scopes(self):
         copy_scopes = self._oneview.scopes
-        self.assertEqual(copy_scopes, self._oneview.scopes)
+        self.assertNotEqual(copy_scopes, self._oneview.scopes)
 
     def test_sas_logical_interconnect_groups_has_right_type(self):
         self.assertIsInstance(self._oneview.sas_logical_interconnect_groups, SasLogicalInterconnectGroups)


### PR DESCRIPTION
### Description
Adding Scopes for API 800, 1000, 1200 and 1600

### Issues Resolved

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [ ] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
