### PR TITLE
Added firmware drivers support till API1600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Extends support of the SDK to OneView REST API version 1600 (OneView v5.20).
 - Ethernet network
 - FC network
 - FCOE network
+- Firmware Drivers
 - Hypervisor Cluster Profiles
 - Hypervisor Managers
 - Interconnects

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -86,6 +86,12 @@
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | PATCH    |  :heavy_minus_sign:   | :heavy_minus_sign:   | :heavy_minus_sign:   |  :heavy_minus_sign:   |
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | PUT      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/fcoe-networks/{id}</sub>                                                      | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|     **Firmware Drivers**
+|<sub>/rest/firmware-drivers</sub>                                                        | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/firmware-drivers</sub>                                                        | POST     |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/firmware-drivers/schema</sub>                                                 | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/firmware-drivers/{id}</sub>                                                   | GET      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
+|<sub>/rest/firmware-drivers/{id}</sub>                                                   | DELETE   |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |     **Hypervisor Cluster Profiles**
 |<sub>/rest/hypervisor-cluster-profiles</sub>                                             |POST      |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |
 |<sub>/rest/hypervisor-cluster-profiles</sub>                                             |GET       |  :white_check_mark:   | :white_check_mark:   | :white_check_mark:   |  :white_check_mark:   |

--- a/examples/firmware_drivers.py
+++ b/examples/firmware_drivers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ###
+
+from pprint import pprint
 
 from config_loader import try_load_from_file
 from hpOneView.oneview_client import OneViewClient
@@ -30,53 +32,58 @@ config = {
 # NOTE: This example requires a SPP and a hotfix inside the appliance.
 
 options = {
-    "customBaselineName": "FirmwareDriver1_Example"
+    "customBaselineName": "FirmwareDriver1_Example",
 }
 
-firmware_name = "HPE Synergy Frame Link Module"
+firmware_name = "HPE Synergy Custom SPP 2019031"
 
 # Try load config from a file (if there is a config file)
 config = try_load_from_file(config)
 oneview_client = OneViewClient(config)
-
-# Get a firmware by name
-print("\nGet firmware by name.")
-firmware = oneview_client.firmware_drivers.get_by('name', firmware_name)[0]
-firmware_uri = firmware['uri']
-print("Found a firmware by name: '{name}'.\n  uri = '{uri}'".format(**firmware))
-
-# Get by Uri
-print("\nGet firmware resource by URI.")
-firmware = oneview_client.firmware_drivers.get(firmware_uri)
-print("Found a firmware by uri: '{0}'.".format(firmware_name))
+firmware_drivers = oneview_client.firmware_drivers
 
 # Get all firmwares
 print("\nGet list of firmwares managed by the appliance.")
-all_firmwares = oneview_client.firmware_drivers.get_all()
+all_firmwares = firmware_drivers.get_all()
 for firmware in all_firmwares:
-    print('  {name}'.format(**firmware))
+    print('  - {}'.format(firmware['name']))
 
-# Getting a SPP and a hotfix from within the Appliance to use in the custom SPP creation.
-try:
-    hotfix = oneview_client.firmware_drivers.get_by('bundleType', "Hotfix")[0]
-    options['hotfixUris'] = [hotfix['uri']]
-    print("\nHotfix named %s found within appliance. Saving for custom SPP." % hotfix['name'])
-except IndexError:
-    raise HPOneViewException('No available hotfixes found within appliance. Stopping run.')
+# Get firmware driver schema
+firmware_schema = firmware_drivers.get_schema()
+pprint(firmware_schema)
 
-try:
-    spp = oneview_client.firmware_drivers.get_by('bundleType', "SPP")[0]
-    options['baselineUri'] = spp['uri']
-    print("\nSPP named %s found within appliance. Saving for custom SPP." % spp['name'])
-except IndexError:
-    raise HPOneViewException('No available SPPs found within appliance. Stopping run.')
+# Get a firmware by name
+print("\nGet firmware by name.")
+firmware_driver = firmware_drivers.get_by_name(firmware_name)
 
-# Create the custom SPP
-print("\nCreate the custom SPP '%s'" % options['customBaselineName'])
-firmware = oneview_client.firmware_drivers.create(options)
-print("  Custom SPP '%s' created successfully" % options['customBaselineName'])
+if firmware_driver:
+    print("Found a firmware by name: '{}'.\n  uri = '{}'".format(firmware_driver.data['name'], firmware_driver.data['uri']))
+else:
+    # Getting a SPP and a hotfix from within the Appliance to use in the custom SPP creation.
+    try:
+        spp = firmware_drivers.get_by('bundleType', "SPP")[0]
+        options['baselineUri'] = spp['uri']
+        print("\nSPP named '{}' found within appliance. Saving for custom SPP.".format(spp['name']))
+    except IndexError:
+        raise HPOneViewException('No available SPPs found within appliance. Stopping run.')
 
-# Remove the firmware
-print("\nDelete the custom SPP '%s'" % options['customBaselineName'])
-oneview_client.firmware_drivers.delete(firmware)
-print("  Custom SPP '%s' deleted successfully" % options['customBaselineName'])
+    try:
+        hotfix = firmware_drivers.get_by('bundleType', "Hotfix")[0]
+        options['hotfixUris'] = [hotfix['uri']]
+        print("\nHotfix named '{}' found within appliance. Saving for custom SPP.".format(hotfix['name']))
+    except IndexError:
+        raise HPOneViewException('No available hotfixes found within appliance. Stopping run.')
+
+    # Create the custom SPP
+    print("\nCreate the custom SPP '{}'".format(options['customBaselineName']))
+    firmware_driver = firmware_drivers.create(options)
+    print("  Custom SPP '%s' created successfully" % options['customBaselineName'])
+
+# Get by Uri
+print("\nGet firmware resource by URI.")
+firmware_data = firmware_drivers.get_by_uri(firmware_driver.data['uri'])
+pprint(firmware_data.data)
+
+# Remove the firmware driver
+firmware_driver.delete()
+print("  Custom SPP '{}' deleted successfully".format(firmware_driver.data['name']))

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -850,9 +850,7 @@ class OneViewClient(object):
         Returns:
             FirmwareDrivers:
         """
-        if not self.__firmware_drivers:
-            self.__firmware_drivers = FirmwareDrivers(self.__connection)
-        return self.__firmware_drivers
+        return FirmwareDrivers(self.__connection)
 
     @property
     def firmware_bundles(self):

--- a/hpOneView/resources/settings/firmware_drivers.py
+++ b/hpOneView/resources/settings/firmware_drivers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,114 +19,20 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-
 from future import standard_library
 
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourceSchemaMixin
 
 
-class FirmwareDrivers(object):
+class FirmwareDrivers(ResourceSchemaMixin, Resource):
     """
-    Firmware Drivers API client.
-
+    The firmware drivers resource managers provides REST APIs to retrieve the firmware bundle inventory data.
+    Note: As per the API docs, 'type' field is not present in the firmware drivers POST call. So default values are not added.
     """
     URI = '/rest/firmware-drivers'
 
-    def __init__(self, con):
-        self._connection = con
-        self._client = ResourceClient(con, self.URI)
-
-    def get_all(self, start=0, count=-1, filter='', sort=''):
-        """
-        Gets a paginated collection of Firmware Drivers. The collection is based on optional sorting and filtering, and
-        constrained by start and count parameters.
-
-        Args:
-            start:
-                The first item to return, using 0-based indexing.
-                If not specified, the default is 0 - start with the first available item.
-            count:
-                The number of resources to return. A count of -1 requests all items.
-                The actual number of items in the response might differ from the requested
-                count if the sum of start and count exceeds the total number of items.
-            filter (list or str):
-                A general filter/query string to narrow the list of items returned. The
-                default is no filter; all resources are returned.
-            sort:
-                The sort order of the returned data set. By default, the sort order is based
-                on create time with the oldest entry first.
-
-        Returns:
-            list: list of firmware baseline resources.
-        """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
-
-    def get_by(self, field, value):
-        """
-        Gets the list of firmware baseline resources managed by the appliance. Optional parameters can be used to
-        filter the list of resources returned.
-
-        The search is case-insensitive.
-
-        Args:
-            field: Field name to filter.
-            value: Value to filter.
-
-        Returns:
-            list: List of firmware baseline resources.
-        """
-        firmwares = self.get_all()
-        matches = []
-        for item in firmwares:
-            if item.get(field) == value:
-                matches.append(item)
-        return matches
-
-    def get(self, id_or_uri):
-        """
-        Gets the individual firmware baseline resource for the given URI.
-
-        Args:
-            id: ID or URI of firmware baseline resource.
-
-        Returns:
-            dict: Firmware baseline resource.
-        """
-        return self._client.get(id_or_uri)
-
-    def create(self, resource, timeout=-1):
-        """
-        Creates a custom SPP (Service Pack for ProLiant) from an existing SPP and one or more hotfixes that have already
-        been added to the system.
-
-        Args:
-            resource (dict): Object to create.
-            timeout:
-                Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView, just stop waiting for its completion.
-
-        Returns:
-            dict: Created resource.
-
-        """
-        return self._client.create(resource, timeout=timeout)
-
-    def delete(self, resource, force=False, timeout=-1):
-        """
-        Delete the firmware baseline resource with the specified ID. If force is set to true, the firmware baseline
-        resource will be deleted even if it is assigned to devices.
-
-        Args:
-            resource (dict): Object to delete
-            force: If set to true, the operation completes despite any problems with
-                network connectivity or errors on the resource itself. The default is false.
-            timeout: Timeout in seconds. Wait for task completion by default. The timeout does not abort the operation
-                in OneView; it just stops waiting for its completion.
-
-        Returns:
-            bool: Indicates if the resource was successfully deleted.
-        """
-        return self._client.delete(resource, force=force, timeout=timeout)
+    def __init__(self, connection, data=None):
+        super(FirmwareDrivers, self).__init__(connection, data)

--- a/tests/unit/resources/settings/test_firmware_drivers.py
+++ b/tests/unit/resources/settings/test_firmware_drivers.py
@@ -20,7 +20,7 @@ from unittest import TestCase
 import mock
 
 from hpOneView.connection import connection
-from hpOneView.resources.resource import Resource, ResourceHelper, ResourceSchemaMixin
+from hpOneView.resources.resource import Resource, ResourceSchemaMixin
 from hpOneView.resources.settings.firmware_drivers import FirmwareDrivers
 
 

--- a/tests/unit/resources/settings/test_firmware_drivers.py
+++ b/tests/unit/resources/settings/test_firmware_drivers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,89 +20,72 @@ from unittest import TestCase
 import mock
 
 from hpOneView.connection import connection
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourceHelper, ResourceSchemaMixin
 from hpOneView.resources.settings.firmware_drivers import FirmwareDrivers
-
-ALL_FIRMWARE_DRIVERS = [
-    {
-        'name': 'Supplemental Update',
-        'uri': '/rest/firmware-drivers/hp-firmware-hdd-a1b08f8a6b-HPGH-1_1_x86_64',
-        'fwComponents': [{'fileName': 'hp-firmware-hdd-a1b08f8a6b-HPGH-1.1.x86_64.rpm'}]
-    },
-    {
-        'name': 'Service Pack for ProLiant.iso',
-        'uri': '/rest/firmware-drivers/spp_gen9_snap6_add-on_bundle',
-        'fwComponents': [{'fileName': 'spp_gen9_snap6_add-on_bundle.zip'}]
-    }
-]
 
 
 class FirmwareDriversTest(TestCase):
-    DEFAULT_HOST = '127.0.0.1'
 
     def setUp(self):
-        oneview_connection = connection(self.DEFAULT_HOST)
-        self.resource = FirmwareDrivers(oneview_connection)
+        self.host = '127.0.0.1'
+        self.connection = connection(self.host)
+        self._firmware_drivers = FirmwareDrivers(self.connection)
+        self.uri = "/rest/firmware-drivers"
+        self._firmware_drivers.data = {"uri": self.uri}
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(Resource, 'get_all')
     def test_get_all(self, mock_get_all):
-        filter_by = 'name=TestName'
+        filter = 'name=TestName'
         sort = 'name:ascending'
 
-        self.resource.get_all(2, 500, filter_by, sort)
-        mock_get_all.assert_called_once_with(2, 500, filter=filter_by, sort=sort)
+        self._firmware_drivers.get_all(2, 500, filter=filter, sort=sort)
+        mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
 
-    @mock.patch.object(ResourceClient, 'get_all')
-    def test_get_by(self, mock_get_all):
-        property_name = 'name'
-        firmware_name = 'Service Pack for ProLiant.iso'
-        expected_result = [ALL_FIRMWARE_DRIVERS[1]]
-        mock_get_all.return_value = ALL_FIRMWARE_DRIVERS
+    @mock.patch.object(Resource, 'get_all')
+    def test_get_all_called_once_with_default(self, mock_get_all):
+        self._firmware_drivers.get_all()
+        mock_get_all.assert_called_once_with()
 
-        result = self.resource.get_by(property_name, firmware_name)
-        self.assertEqual(expected_result, result)
+    @mock.patch.object(Resource, 'get_by_uri')
+    def test_get_by_uri_called_once(self, mock_get_by_uri):
+        uri = "/rest/firmware-drivers/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
+        self._firmware_drivers.get_by_uri(uri)
+        mock_get_by_uri.assert_called_once_with(uri)
 
-    @mock.patch.object(ResourceClient, 'get_all')
-    def test_get_by_without_match(self, mock_get_all):
-        property_name = 'name'
-        firmware_name = 'Service Pack for ProLiant X64'
-        mock_get_all.return_value = ALL_FIRMWARE_DRIVERS
+    @mock.patch.object(Resource, 'get_by')
+    def test_get_by_called_once(self, mock_get_by):
+        drivers = [{'name': 'name1', 'type': 'SPP'}, {'name': 'name2', 'type': 'HotFix'}]
+        mock_get_by.return_value = drivers
+        result = self._firmware_drivers.get_by("type", 'SPP')
+        mock_get_by.assert_called_once_with("type", 'SPP')
+        self.assertEqual(result, drivers)
 
-        result = self.resource.get_by(property_name, firmware_name)
-        self.assertEqual(0, len(result))
+    @mock.patch.object(Resource, 'get_by')
+    def test_get_by_name_called_once(self, mock_get_by_name):
+        drivers = [{'name': 'name1', 'type': 'SPP'}, {'name': 'name2', 'type': 'HotFix'}]
+        mock_get_by_name.return_value = drivers
+        result = self._firmware_drivers.get_by_name("name1")
+        mock_get_by_name.assert_called_once_with("name", "name1")
+        self.assertEqual(result.data['type'], 'SPP')
 
-    @mock.patch.object(ResourceClient, 'get_all')
-    def test_get_by_when_there_are_not_any_firmware(self, mock_get_all):
-        property_name = 'name'
-        firmware_name = 'Service Pack for ProLiant X64'
-        mock_get_all.return_value = []
+    @mock.patch.object(ResourceSchemaMixin, 'get_schema')
+    def test_get_schema(self, mock_get_schema):
+        self._firmware_drivers.get_schema()
+        mock_get_schema.assert_called_once()
 
-        result = self.resource.get_by(property_name, firmware_name)
-        self.assertEqual(0, len(result))
+    @mock.patch.object(Resource, 'create')
+    def test_add_called_once_with_defaults(self, mock_create):
+        resource = dict(
+            customBaselineName="FirmwareDriver1_Example",
+        )
 
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_by_id(self, mock_get):
-        firmware_id = "SPP2012080.2012_0713.57"
-
-        self.resource.get(firmware_id)
-        mock_get.assert_called_once_with(firmware_id)
-
-    @mock.patch.object(ResourceClient, 'create')
-    def test_create_should_use_given_values(self, mock_create):
-        resource = {
-            'customBaselineName': 'FirmwareDriver1_Example',
-            'baselineUri': '/rest/fakespp',
-            'hotfixUris': ['/rest/fakehotfix']
-        }
         resource_rest_call = resource.copy()
         mock_create.return_value = {}
 
-        self.resource.create(resource, 30)
-        mock_create.assert_called_once_with(resource_rest_call, timeout=30)
+        self._firmware_drivers.create(resource)
+        mock_create.assert_called_once_with(resource_rest_call)
 
-    @mock.patch.object(ResourceClient, 'delete')
-    def test_remove(self, mock_delete):
-        fake_firmware = dict(name='Service Pack for ProLiant.iso')
-
-        self.resource.delete(fake_firmware)
-        mock_delete.assert_called_once_with(fake_firmware, force=False, timeout=-1)
+    @mock.patch.object(Resource, 'delete')
+    def test_delete_called_once_with_force(self, mock_delete):
+        self._firmware_drivers.delete(force=True)
+        mock_delete.assert_called_once_with(force=True)

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -28,6 +28,7 @@ from hpOneView.resources.facilities.racks import Racks
 from hpOneView.resources.fc_sans.managed_sans import ManagedSANs
 from hpOneView.resources.fc_sans.san_managers import SanManagers
 from hpOneView.resources.fc_sans.endpoints import Endpoints
+from hpOneView.resources.settings.firmware_drivers import FirmwareDrivers
 from hpOneView.resources.settings.backups import Backups
 from hpOneView.resources.settings.restores import Restores
 from hpOneView.resources.settings.scopes import Scopes
@@ -560,9 +561,12 @@ class OneViewClientTest(unittest.TestCase):
         storage_pools = self._oneview.storage_pools
         self.assertNotEqual(storage_pools, self._oneview.storage_pools)
 
-    def test_lazy_loading_firmware_drivers(self):
+    def test_firmware_drivers_has_right_type(self):
+        self.assertIsInstance(self._oneview.firmware_drivers, FirmwareDrivers)
+
+    def test_firmware_drivers_client(self):
         firmware_drivers = self._oneview.firmware_drivers
-        self.assertEqual(firmware_drivers, self._oneview.firmware_drivers)
+        self.assertNotEqual(firmware_drivers, self._oneview.firmware_drivers)
 
     def test_lazy_loading_firmware_bundles(self):
         firmware_bundles = self._oneview.firmware_bundles


### PR DESCRIPTION
### Description
Added firmware drivers support from API 800 to 1600

### Issues Resolved
#20 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
