### PR TITLE
Artifact bundles support fot Api1600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Extends support of the SDK to OneView REST API version 1600 (OneView v5.20).
 
 #### Features supported with the current release
 - Appliance SNMPv1 Trap Destinations
+- Artifact Bundles
 - Certificates Server
 - Deployment plan
 - Enclosures

--- a/endpoints-support.md
+++ b/endpoints-support.md
@@ -366,3 +366,19 @@
 |<sub> /rest/deployment-plans/{id} </sub>                                         | DELETE           |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |<sub> /rest/deployment-plans/{id}/usedby </sub>                                  | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 |<sub> /rest/deployment-plans/{id}/osdp </sub>                                    | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|     **Artifact Bundles**
+|<sub> /rest/artifact-bundles </sub>                                              | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles </sub>                                              | POST             |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles </sub>                                              | POST             |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/backups </sub>                                      | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/backups </sub>                                      | POST             |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/backups/archive </sub>                              | POST             |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/backups/archive/{id} </sub>                         | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/backups/{id} </sub>                                 | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/backups/{id} </sub>                                 | PUT              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/download/{id} </sub>                                | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/{id} </sub>                                         | GET              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/{id} </sub>                                         | PUT              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/{id} </sub>                                         | PUT              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/{id} </sub>                                         | DELETE           |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+|<sub> /rest/artifact-bundles/{id}/stopArtifactCreate </sub>                      | PUT              |  :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/examples/image_streamer/artifact_bundles.py
+++ b/examples/image_streamer/artifact_bundles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,132 +22,109 @@ from hpOneView.oneview_client import OneViewClient
 EXAMPLE_CONFIG_FILE = os.path.join(os.path.dirname(__file__), '../config.json')
 
 oneview_client = OneViewClient.from_json_file(EXAMPLE_CONFIG_FILE)
-
 image_streamer_client = oneview_client.create_image_streamer_client()
+artifact_bundles = image_streamer_client.artifact_bundles
 
-artifact_bundles_to_be_created = {
+artifact_bundles_to_be_created= {
     "name": "Artifact Bundles Test",
     "description": "Description of Artifact Bundles Test",
     "buildPlans": [
         {
-            "resourceUri": "/rest/build-plans/3ec91dd2-0ebb-4484-8b2d-90d065114315",
+            "resourceUri": "/rest/build-plans/81088ef9-631d-4c5c-9de1-026afa234bc8",
             "readOnly": "false"
         }
     ]
 }
 
 artifact_bundles_deployment_group = {
-    "deploymentGroupURI": "/rest/deployment-groups/c5a727ef-71e9-4154-a512-6655b168c2e3"
+    "deploymentGroupURI": "/rest/deployment-groups/2117634b-d911-4673-98ac-1a7e19f3b40f"
 }
 
 artifact_bundle_file_path = {
-    "download": "~/artifact_bundle.zip",
-    "download_archive": "~/archive.zip",
-    "name_upload": "artifact_bundle",
-    "upload": "~/artifact_bundle.zip",
-    "upload_backup": "~/backup.zip"
+    "download": "./artifact_bundle.zip",
+    "download_archive": "./archive.zip",
+    "upload": "./artifact_bundle.zip",
+    "upload_backup": "./archive.zip"
 }
 
 artifact_bundle_new_name = "Artifact Bundles Test Updated"
 
-# Create an Artifact Bundle
-print("\nCreate an Artifact Bundle")
-response = image_streamer_client.artifact_bundles.create(artifact_bundles_to_be_created)
-pprint(response)
-
-
 # Get all Artifacts Bundle
 print("\nGet all Artifact Bundles")
-artifact_bundles = image_streamer_client.artifact_bundles.get_all()
-for artifacts_bundle in artifact_bundles:
-    pprint(artifacts_bundle)
-
+all_artifact_bundles = artifact_bundles.get_all()
+for artifacts_bundle in all_artifact_bundles:
+    print(" - {}".format(artifacts_bundle['name']))
 
 # Get the Artifacts Bundle by Name
 print("\nGet Artifact Bundles by Name")
-artifact_bundle = image_streamer_client.artifact_bundles.get_by_name(artifact_bundles_to_be_created['name'])
-pprint(artifact_bundle)
+artifact_bundle = artifact_bundles.get_by_name(artifact_bundles_to_be_created['name'])
 
+if artifact_bundle:
+    print("Found artifact bundle with name- {} and uri- {}".format(artifact_bundle.data['name'], artifact_bundle.data['uri']))
+else:
+    # Create an Artifact Bundle
+    print("\nCreate an Artifact Bundle")
+    artifact_bundle = artifact_bundles.create(artifact_bundles_to_be_created)
+    print("Created artifact bundle with name- {} and uri- {}".format(artifact_bundle.data['name'], artifact_bundle.data['uri']))
 
-# Get the Artifacts Bundle
-print("\nGet the Artifact Bundle")
-response = image_streamer_client.artifact_bundles.get(artifact_bundle['uri'])
-pprint(response)
-
+# Get the Artifacts Bundle by uri
+print("\nGet the Artifact Bundle by uri")
+ab_by_uri = artifact_bundles.get_by_uri(artifact_bundle.data['uri'])
+print(ab_by_uri.data)
 
 # Download the Artifact Bundle
 print("\nDownload the Artifact Bundle")
-response = image_streamer_client.artifact_bundles.download_artifact_bundle(
-    artifact_bundle['uri'], artifact_bundle_file_path['download'])
-pprint(response)
+response = artifact_bundle.download(artifact_bundle_file_path['download'])
+print(response)
 
-
-# Download the Archive of the Artifact Bundle
-print("\nDownload the Archive of the Artifact Bundle")
-response = image_streamer_client.artifact_bundles\
-    .download_archive_artifact_bundle(artifact_bundle['uri'], artifact_bundle_file_path['download_archive'])
-pprint(response)
-
+# Update name of an Artifact Bundle
+print("\nUpdate an Artifact Bundle")
+data_to_update = {'name': artifact_bundle_new_name}
+artifact_bundle.update(data=data_to_update)
+pprint(artifact_bundle.data)
 
 # Extract an Artifact Bundle
 print("\nExtract an Artifact Bundle")
-response = image_streamer_client.artifact_bundles.extract_bundle(artifact_bundle)
+response = artifact_bundle.extract()
 pprint(response)
-
-
-# Update an Artifact Bundle
-print("\nUpdate an Artifact Bundle")
-artifact_bundle = image_streamer_client.artifact_bundles.get_by_name(artifact_bundles_to_be_created['name'])
-artifact_bundle['name'] = artifact_bundle_new_name
-response = image_streamer_client.artifact_bundles.update(artifact_bundle)
-pprint(response)
-
 
 # Delete an Artifact Bundle
 print("\nDelete an Artifact Bundle")
-artifact_bundle = image_streamer_client.artifact_bundles.get_by_name(artifact_bundle_new_name)
-image_streamer_client.artifact_bundles.delete(artifact_bundle)
+artifact_bundle.delete()
 
-
-# Create a Backup for the Artifact Bundle
-print("\nCreate a Backup for Artifact Bundle")
-response = image_streamer_client.artifact_bundles.create_backup(artifact_bundles_deployment_group)
-pprint(response)
-
+# Create a Backup for all the Artifact Bundle
+print("\nCreate a Backup for all Artifact Bundles")
+ab_backup = artifact_bundles.create_backup(artifact_bundles_deployment_group)
+print(ab_backup.data)
 
 # Get all Backups Bundles
 print("\nGet all Backups Bundles")
-backups_artifacts_bundle = image_streamer_client.artifact_bundles.get_all_backups()
-pprint(backups_artifacts_bundle)
-
+backup_artifact_bundles = artifact_bundles.get_all_backups()
+for backup in backup_artifact_bundles:
+    print(" - {}".format(backup['name']))
 
 # Get Backup Bundle
 print("\nGet Backup Bundle")
-artifacts_bundle = image_streamer_client.artifact_bundles.get_backup(backups_artifacts_bundle[0]['uri'])
-pprint(artifacts_bundle)
+ab_bkp = artifact_bundles.get_backup(backup_artifact_bundles[0]['uri'])
+pprint(ab_bkp.data)
 
+# Extract an Artifact Bundle from backup
+print("\nExtract an Artifact Bundle from Backup")
+response = ab_bkp.extract_backup(artifact_bundles_deployment_group)
+pprint(response)
+
+# Download the backup archive of the Artifact Bundle
+print("\nDownload the backup archive of the Artifact Bundle")
+response = ab_bkp.download_archive(artifact_bundle_file_path['download_archive'])
+print(response)
 
 # Upload an Artifact Bundle from file
 print("\nUpload an Artifact Bundle from file")
-response = image_streamer_client.artifact_bundles.upload_bundle_from_file(artifact_bundle_file_path['upload'])
+response = artifact_bundles.upload_bundle_from_file(artifact_bundle_file_path['upload'])
 pprint(response)
-
 
 # Upload a Backup of Artifact Bundle from file
 print("\nUpload a Backup of Artifact Bundle from file")
-response = image_streamer_client.artifact_bundles\
-    .upload_backup_bundle_from_file(artifact_bundle_file_path['upload_backup'],
+response = artifact_bundles.upload_backup_bundle_from_file(artifact_bundle_file_path['upload_backup'],
                                     artifact_bundles_deployment_group['deploymentGroupURI'])
 pprint(response)
-
-
-# Extract an Artifact Bundle
-print("\nExtract an Artifact Bundle from Backup")
-response = image_streamer_client.artifact_bundles.extract_backup_bundle(artifact_bundles_deployment_group)
-pprint(response)
-
-
-# Delete the Artifact Bundle created from file
-print("\nDelete the Artifact Bundle created from file")
-artifact_bundle = image_streamer_client.artifact_bundles.get_by_name(artifact_bundle_file_path['name_upload'])
-image_streamer_client.artifact_bundles.delete(artifact_bundle)

--- a/examples/image_streamer/artifact_bundles.py
+++ b/examples/image_streamer/artifact_bundles.py
@@ -25,7 +25,7 @@ oneview_client = OneViewClient.from_json_file(EXAMPLE_CONFIG_FILE)
 image_streamer_client = oneview_client.create_image_streamer_client()
 artifact_bundles = image_streamer_client.artifact_bundles
 
-artifact_bundles_to_be_created= {
+artifact_bundles_to_be_created = {
     "name": "Artifact Bundles Test",
     "description": "Description of Artifact Bundles Test",
     "buildPlans": [
@@ -125,6 +125,5 @@ pprint(response)
 
 # Upload a Backup of Artifact Bundle from file
 print("\nUpload a Backup of Artifact Bundle from file")
-response = artifact_bundles.upload_backup_bundle_from_file(artifact_bundle_file_path['upload_backup'],
-                                    artifact_bundles_deployment_group['deploymentGroupURI'])
-pprint(response)
+res = artifact_bundles.upload_backup_bundle_from_file(artifact_bundle_file_path['upload_backup'], artifact_bundles_deployment_group['deploymentGroupURI'])
+pprint(res)

--- a/hpOneView/image_streamer/image_streamer_client.py
+++ b/hpOneView/image_streamer/image_streamer_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -125,9 +125,7 @@ class ImageStreamerClient(object):
         Returns:
             ArtifactBundles:
         """
-        if not self.__artifact_bundles:
-            self.__artifact_bundles = ArtifactBundles(self.__connection)
-        return self.__artifact_bundles
+        return ArtifactBundles(self.__connection)
 
     @property
     def deployment_groups(self):

--- a/hpOneView/image_streamer/resources/artifact_bundles.py
+++ b/hpOneView/image_streamer/resources/artifact_bundles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,92 +24,22 @@ from future import standard_library
 standard_library.install_aliases()
 
 
-from hpOneView.resources.resource import ResourceClient, extract_id_from_uri
+from hpOneView.resources.resource import Resource, ResourceFileHandlerMixin, extract_id_from_uri
 
 
-class ArtifactBundles(object):
+class ArtifactBundles(ResourceFileHandlerMixin, Resource):
 
     URI = '/rest/artifact-bundles'
-    DEPLOYMENT_GROUPS_URI = '/rest/deployment-groups/'
     BACKUPS_PATH = '/rest/artifact-bundles/backups'
     BACKUP_ARCHIVE_PATH = '/rest/artifact-bundles/backups/archive'
-    STOP_CREATION_PATH = '/stopArtifactCreate'
     DOWNLOAD_PATH = '/rest/artifact-bundles/download'
 
     DEFAULT_VALUES = {
         '300': {"type": "ArtifactsBundle"}
     }
 
-    def __init__(self, con):
-        self._client = ResourceClient(con, self.URI)
-        self.__default_values = {
-            'type': 'ArtifactsBundle',
-        }
-
-    def get_all(self, start=0, count=-1, filter='', sort=''):
-        """
-        Gets a list of Artifacts Bundle based on optional sorting and filtering, and constrained by start and count
-        parameters.
-
-        Args:
-            start:
-                The first item to return, using 0-based indexing.
-                If not specified, the default is 0 - start with the first available item.
-            count:
-                The number of resources to return. A count of -1 requests all items.
-
-                The actual number of items in the response might differ from the requested
-                count if the sum of start and count exceeds the total number of items.
-            filter (list or str):
-                A general filter/query string to narrow the list of items returned. The
-                default is no filter; all resources are returned.
-            sort:
-                The sort order of the returned data set. By default, the sort order is based
-                on create time with the oldest entry first.
-
-        Returns:
-            list: A list of Artifacts Bundle.
-        """
-        return self._client.get_all(start, count, filter=filter, sort=sort)
-
-    def get(self, id_or_uri):
-        """
-        Retrieves the overview details for the selected Artifact Bundle as per the selected attributes.
-
-        Args:
-            id_or_uri: ID or URI of the Artifact Bundle.
-
-        Returns:
-            dict: The Artifact Bundle.
-        """
-        return self._client.get(id_or_uri)
-
-    def get_by(self, field, value):
-        """
-        Gets all of the Artifacts Bundle resources that match the filter.
-
-        The search is case-insensitive.
-
-        Args:
-            field: Field name to filter.
-            value: Value to filter.
-
-        Returns:
-            list: The Artifacts Bundle.
-        """
-        return self._client.get_by(field, value)
-
-    def get_by_name(self, name):
-        """
-        Gets an Artifact Bundle by name.
-
-        Args:
-            name: Name of the Artifact Bundle.
-
-        Returns:
-            dict: The Artifact Bundle.
-        """
-        return self._client.get_by_name(name)
+    def __init__(self, connection, data=None):
+        super(ArtifactBundles, self).__init__(connection, data)
 
     def get_all_backups(self):
         """
@@ -118,49 +48,54 @@ class ArtifactBundles(object):
         Returns:
             list: A list of Backups for Artifacts Bundle.
         """
-        return self._client.get_collection(id_or_uri=self.BACKUPS_PATH)
+        return self._helper.get_collection(uri=self.BACKUPS_PATH)
 
-    def get_backup(self, id_or_uri):
+    def get_backup(self, uri):
         """
         Get the details for the backup from an Artifact Bundle.
 
         Args:
-            id_or_uri: ID or URI of the Artifact Bundle.
+            uri: URI of the Artifact Bundle.
 
         Returns:
             Dict: Backup for an Artifacts Bundle.
         """
-        uri = self.BACKUPS_PATH + '/' + extract_id_from_uri(id_or_uri)
-        return self._client.get(id_or_uri=uri)
+        uri = self.BACKUPS_PATH + '/' + extract_id_from_uri(uri)
+        return super(ArtifactBundles, self).get_by_uri(uri)
 
-    def download_archive_artifact_bundle(self, id_or_uri, file_path):
+    def download_archive(self, path, uri=None):
         """
-        Downloads an archive for the Artifact Bundle.
+        Downloads backup archive for the Artifact Bundle.
 
         Args:
-            id_or_uri: ID or URI of the Artifact Bundle.
-            file_path(str): Destination file path.
+            path(str): Destination file path.
+            uri: URI of the Artifact Bundle.
 
         Returns:
             bool: Successfully downloaded.
         """
+        if not uri:
+            uri = self.data['uri']
 
-        uri = self.BACKUP_ARCHIVE_PATH + '/' + extract_id_from_uri(id_or_uri)
-        return self._client.download(uri, file_path)
+        download_uri = self.BACKUP_ARCHIVE_PATH + '/' + extract_id_from_uri(uri)
+        return super(ArtifactBundles, self).download(download_uri, path)
 
-    def download_artifact_bundle(self, id_or_uri, file_path):
+    def download(self, path, uri=None):
         """
         Download the Artifact Bundle.
 
         Args:
-            id_or_uri: ID or URI of the Artifact Bundle.
-            file_path(str): Destination file path.
+            uri: URI of the Artifact Bundle.
+            path(str): Destination file path.
 
         Returns:
             bool: Successfully downloaded.
         """
-        uri = self.DOWNLOAD_PATH + '/' + extract_id_from_uri(id_or_uri)
-        return self._client.download(uri, file_path)
+        if not uri:
+            uri = self.data['uri']
+
+        download_uri = self.DOWNLOAD_PATH + '/' + extract_id_from_uri(uri)
+        return super(ArtifactBundles, self).download(download_uri, path)
 
     def create_backup(self, resource, timeout=-1):
         """
@@ -176,7 +111,7 @@ class ArtifactBundles(object):
         Returns:
             dict: A Deployment Group associated with the Artifact Bundle backup.
         """
-        return self._client.create(resource, uri=self.BACKUPS_PATH, timeout=timeout)
+        return super(ArtifactBundles, self).create(resource, uri=self.BACKUPS_PATH, timeout=timeout)
 
     def upload_bundle_from_file(self, file_path):
         """
@@ -188,80 +123,29 @@ class ArtifactBundles(object):
         Returns:
             dict: Artifact bundle.
         """
-        return self._client.upload(file_path)
+        return super(ArtifactBundles, self).upload(file_path)
 
-    def upload_backup_bundle_from_file(self, file_path, deployment_groups_id_or_uri):
+    def upload_backup_bundle_from_file(self, file_path, deployment_group_uri):
         """
         Restore an Artifact Bundle from a backup file.
 
         Args:
             file_path (str): The File Path to restore the Artifact Bundle.
-            deployment_groups_id_or_uri: ID or URI of the Deployment Groups.
+            deployment_group_uri: URI of the Deployment Groups.
 
         Returns:
             dict: Deployment group.
         """
-        deployment_groups_uri = deployment_groups_id_or_uri
+        uri = self.BACKUP_ARCHIVE_PATH + "?deploymentGrpUri=" + deployment_group_uri
+        return super(ArtifactBundles, self).upload(file_path, uri)
 
-        if self.DEPLOYMENT_GROUPS_URI not in deployment_groups_id_or_uri:
-            deployment_groups_uri = self.DEPLOYMENT_GROUPS_URI + deployment_groups_id_or_uri
-
-        uri = self.BACKUP_ARCHIVE_PATH + "?deploymentGrpUri=" + deployment_groups_uri
-
-        return self._client.upload(file_path, uri)
-
-    def create(self, resource, timeout=-1):
-        """
-        Creates an Artifact Bundle.
-
-        Args:
-            resource (dict): Object to create.
-            timeout:
-                Timeout in seconds. Waits for task completion by default. The timeout does not abort the operation
-                in OneView, it just stops waiting for its completion.
-
-        Returns:
-            dict: Created resource.
-        """
-        return self._client.create(resource, timeout=timeout)
-
-    def delete(self, resource, timeout=-1):
-        """
-        Deletes an Artifact Bundle.
-
-        Args:
-            resource(str, dict):
-                Accept either the resource id  or the entire resource.
-            timeout:
-                Timeout in seconds. Waits for task completion by default. The timeout does not abort the operation in
-                OneView, it just stops waiting for its completion.
-
-        Returns:
-            bool: Indicates if the resource was successfully deleted.
-        """
-        return self._client.delete(resource, timeout=timeout)
-
-    def update(self, resource, timeout=-1):
-        """
-        Updates only name for the Artifact Bundle.
-
-        Args:
-            resource (dict): Object to update.
-            timeout:
-                Timeout in seconds. Waits for task completion by default. The timeout does not abort the operation
-                in OneView, it just stops waiting for its completion.
-
-        Returns:
-            dict: Updated resource.
-        """
-        return self._client.update(resource, timeout=timeout, default_values=self.DEFAULT_VALUES)
-
-    def extract_bundle(self, resource, timeout=-1):
+    def extract(self, resource=None, uri=None, timeout=-1):
         """
         Extracts the existing bundle on the appliance and creates all the artifacts.
 
         Args:
             resource (dict): Artifact Bundle to extract.
+            uri: URI of artifact bundle
             timeout:
                 Timeout in seconds. Waits for task completion by default. The timeout does not abort the operation in
                 OneView, it just stops waiting for its completion.
@@ -269,14 +153,19 @@ class ArtifactBundles(object):
         Returns:
             dict: The Artifact Bundle.
         """
-        return self._client.update(resource, timeout=timeout, custom_headers={"Content-Type": "text/plain"})
+        if not uri:
+            uri = self.data['uri']
 
-    def extract_backup_bundle(self, resource, timeout=-1):
+        extract_uri = "{}?extract=true&forceImport=true".format(uri)
+        return self._helper.update(resource, extract_uri, timeout=timeout, custom_headers={"Content-Type": "text/plain;charset=UTF-8"})
+
+    def extract_backup(self, resource, uri=None, timeout=-1):
         """
         Extracts the existing backup bundle on the appliance and creates all the artifacts.
 
         Args:
             resource (dict): Deployment Group to extract.
+            uri: URI of artifact backup
             timeout:
                 Timeout in seconds. Waits for task completion by default. The timeout does not abort the operation in
                 OneView, it just stops waiting for its completion.
@@ -284,23 +173,29 @@ class ArtifactBundles(object):
         Returns:
             dict: A Deployment Group associated with the Artifact Bundle backup.
         """
-        return self._client.update(resource, uri=self.BACKUP_ARCHIVE_PATH, timeout=timeout)
+        if not uri:
+            uri = self.data['uri']
 
-    def stop_artifact_creation(self, id_or_uri, task_uri):
+        extract_uri = self.BACKUPS_PATH + '/' + extract_id_from_uri(uri)
+        return self._helper.update(resource, extract_uri, timeout=timeout)
+
+    def stop_artifact_creation(self, task_uri, uri=None):
         """
         Stops creation of the selected Artifact Bundle.
 
         Args:
-            id_or_uri: ID or URI of the Artifact Bundle.
             task_uri: Task URI associated with the Artifact Bundle.
+            uri: URI of the Artifact Bundle.
 
         Returns:
             string:
         """
+        if not uri:
+            uri = self.data['uri']
+
         data = {
             "taskUri": task_uri
         }
 
-        uri = self.URI + '/' + extract_id_from_uri(id_or_uri) + self.STOP_CREATION_PATH
-
-        return self._client.update(data, uri=uri)
+        stop_uri = "{}/stopArtifactCreate".format(uri)
+        return self._helper.update(data, uri=stop_uri)

--- a/hpOneView/image_streamer/resources/artifact_bundles.py
+++ b/hpOneView/image_streamer/resources/artifact_bundles.py
@@ -34,15 +34,11 @@ class ArtifactBundles(ResourceFileHandlerMixin, Resource):
     BACKUP_ARCHIVE_PATH = '/rest/artifact-bundles/backups/archive'
     DOWNLOAD_PATH = '/rest/artifact-bundles/download'
 
-    DEFAULT_VALUES = {
-        '800': {"type": "ArtifactsBundle"},
-        '1000': {"type": "ArtifactsBundle"},
-        '1020': {"type": "ArtifactsBundle"},
-        '1600': {"type": "ArtifactsBundle"}
-    }
-
     def __init__(self, connection, data=None):
         super(ArtifactBundles, self).__init__(connection, data)
+        self.__default_values = {
+            'type': 'ArtifactsBundle'
+        }
 
     def get_all_backups(self):
         """

--- a/hpOneView/image_streamer/resources/artifact_bundles.py
+++ b/hpOneView/image_streamer/resources/artifact_bundles.py
@@ -35,7 +35,10 @@ class ArtifactBundles(ResourceFileHandlerMixin, Resource):
     DOWNLOAD_PATH = '/rest/artifact-bundles/download'
 
     DEFAULT_VALUES = {
-        '300': {"type": "ArtifactsBundle"}
+        '800': {"type": "ArtifactsBundle"},
+        '1000': {"type": "ArtifactsBundle"},
+        '1020': {"type": "ArtifactsBundle"},
+        '1600': {"type": "ArtifactsBundle"}
     }
 
     def __init__(self, connection, data=None):

--- a/tests/unit/image_streamer/resources/test_artifact_bundles.py
+++ b/tests/unit/image_streamer/resources/test_artifact_bundles.py
@@ -67,7 +67,6 @@ class ArtifactBundlesTest(TestCase):
 
     @mock.patch.object(ResourceFileHandlerMixin, 'download')
     def test_download_called_once_by_uri(self, mock_download):
-        uri = '/rest/artifact-bundles/test'
         destination = '~/image.zip'
 
         self._artifact_bundles.download(destination)

--- a/tests/unit/image_streamer/resources/test_artifact_bundles.py
+++ b/tests/unit/image_streamer/resources/test_artifact_bundles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,192 +21,96 @@ import mock
 
 from hpOneView.connection import connection
 from hpOneView.image_streamer.resources.artifact_bundles import ArtifactBundles
-from hpOneView.resources.resource import ResourceClient
+from hpOneView.resources.resource import Resource, ResourceHelper, ResourceFileHandlerMixin
 
 
 class ArtifactBundlesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
         self.connection = connection(self.host)
-        self._client = ArtifactBundles(self.connection)
+        self._artifact_bundles = ArtifactBundles(self.connection)
+        self.uri = "/rest/artifact-bundles/test"
+        self._artifact_bundles.data = {"uri": self.uri}
 
-    @mock.patch.object(ResourceClient, 'get_all')
+    @mock.patch.object(Resource, 'get_all')
     def test_get_all_called_once(self, mock_get_all):
         filter = 'name=TestName'
-        sort = 'name: ascending'
+        sort = 'name:ascending'
 
-        self._client.get_all(2, 500, filter, sort)
-
+        self._artifact_bundles.get_all(2, 500, filter=filter, sort=sort)
         mock_get_all.assert_called_once_with(2, 500, filter=filter, sort=sort)
 
-    @mock.patch.object(ResourceClient, 'get_all')
-    def test_get_all_called_once_with_default_values(self, mock_get_all):
-        self._client.get_all()
+    @mock.patch.object(Resource, 'get_all')
+    def test_get_all_called_once_with_default(self, mock_get_all):
+        self._artifact_bundles.get_all()
+        mock_get_all.assert_called_once_with()
 
-        mock_get_all.assert_called_once_with(0, -1, filter='', sort='')
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_called_once(self, mock_get):
-        self._client.get('78836581-2b6f-4e26-9969-5667fb5837b4')
-
-        mock_get.assert_called_once_with(
-            '78836581-2b6f-4e26-9969-5667fb5837b4')
-
-    @mock.patch.object(ResourceClient, 'get')
-    def test_get_with_uri_called_once(self, mock_get):
-        uri = '/rest/artifact-bundles/78836581-2b6f-4e26-9969-5667fb5837b4'
-        self._client.get(uri)
-
-        mock_get.assert_called_once_with(uri)
-
-    @mock.patch.object(ResourceClient, 'get_by')
-    def test_get_by_called_once(self, mock_get_by):
-        self._client.get_by('name', 'ArtifactBundle')
-
-        mock_get_by.assert_called_once_with(
-            'name', 'ArtifactBundle')
-
-    @mock.patch.object(ResourceClient, 'get_by_name')
-    def test_get_by_name_called_once(self, mock_get_by):
-        self._client.get_by_name('ArtifactBundle')
-
-        mock_get_by.assert_called_once_with('ArtifactBundle')
-
-    @mock.patch.object(ResourceClient, 'create')
-    def test_create_called_once(self, mock_create):
-        information = {
-            "name": "ArtifactBundle"
-        }
-        mock_create.return_value = {}
-
-        self._client.create(information)
-        mock_create.assert_called_once_with(information.copy(), timeout=-1)
-
-    @mock.patch.object(ResourceClient, 'update')
-    def test_update_called_once(self, mock_update):
-        information = {
-            "name": "ArtifactBundleUpdate",
-            "uri": "/rest/artifact-bundles/78836581-2b6f-4e26-9969-5667fb5837b4"
-        }
-        mock_update.return_value = {}
-
-        self._client.update(information)
-
-        default_values = {u'300': {u'type': u'ArtifactsBundle'}}
-
-        mock_update.assert_called_once_with(information.copy(), default_values=default_values, timeout=-1)
-
-    @mock.patch.object(ResourceClient, 'delete')
-    def test_remove_called_once(self, mock_delete):
-        id = '78836581-2b6f-4e26-9969-5667fb5837b4'
-        self._client.delete(id)
-
-        mock_delete.assert_called_once_with(id, timeout=-1)
-
-    @mock.patch.object(ResourceClient, 'get_collection')
+    @mock.patch.object(ResourceHelper, 'get_collection')
     def test_get_all_backups_called_once(self, mock_get_collection):
         uri = '/rest/artifact-bundles/backups'
-        self._client.get_all_backups()
+        self._artifact_bundles.get_all_backups()
+        mock_get_collection.assert_called_once_with(uri=uri)
 
-        mock_get_collection.assert_called_once_with(id_or_uri=uri)
-
-    @mock.patch.object(ResourceClient, 'get')
+    @mock.patch.object(Resource, 'get_by_uri')
     def test_get_backups_by_id_called_once(self, mock_get):
-        uri = '/rest/artifact-bundles/backups'
-        id = '78836581-2b6f-4e26-9969-5667fb5837b4'
-        self._client.get_backup(id)
+        uri = '/rest/artifact-bundles/backups/test'
+        self._artifact_bundles.get_backup(uri)
+        mock_get.assert_called_once_with(uri)
 
-        mock_get.assert_called_once_with(id_or_uri=uri + '/' + id)
-
-    @mock.patch.object(ResourceClient, 'download')
-    def test_download_called_once_by_id(self, mock_download):
-        destination = '~/image.zip'
-        self._client.download_artifact_bundle('0ABDE00534F', destination)
-
-        mock_download.assert_called_once_with('/rest/artifact-bundles/download/0ABDE00534F', destination)
-
-    @mock.patch.object(ResourceClient, 'download')
-    def test_download_called_once_by_uri(self, mock_download):
-        uri = '/rest/artifact-bundles/0ABDE00534F'
-        destination = '~/image.zip'
-
-        self._client.download_artifact_bundle(uri, destination)
-
-        mock_download.assert_called_once_with('/rest/artifact-bundles/download/0ABDE00534F', destination)
-
-    @mock.patch.object(ResourceClient, 'download')
-    def test_download_archive_artifact_bundle_by_id_called_once(self, mock_download):
-        id = '78836581-2b6f-4e26-9969-5667fb5837b4'
-        destination = '~/image.zip'
-
-        self._client.download_archive_artifact_bundle(id, destination)
-
-        expected_uri = '/rest/artifact-bundles/backups/archive/78836581-2b6f-4e26-9969-5667fb5837b4'
-        mock_download.assert_called_once_with(expected_uri, destination)
-
-    @mock.patch.object(ResourceClient, 'download')
+    @mock.patch.object(ResourceFileHandlerMixin, 'download')
     def test_download_archive_artifact_bundle_by_uri_called_once(self, mock_download):
-        uri = '/rest/artifact-bundles/78836581-2b6f-4e26-9969-5667fb5837b4'
         destination = '~/image.zip'
+        expected_uri = '/rest/artifact-bundles/backups/archive/test'
 
-        self._client.download_archive_artifact_bundle(uri, destination)
-
-        expected_uri = '/rest/artifact-bundles/backups/archive/78836581-2b6f-4e26-9969-5667fb5837b4'
+        self._artifact_bundles.download_archive(destination)
         mock_download.assert_called_once_with(expected_uri, destination)
 
-    @mock.patch.object(ResourceClient, 'create')
+    @mock.patch.object(ResourceFileHandlerMixin, 'download')
+    def test_download_called_once_by_uri(self, mock_download):
+        uri = '/rest/artifact-bundles/test'
+        destination = '~/image.zip'
+
+        self._artifact_bundles.download(destination, uri)
+        mock_download.assert_called_once_with('/rest/artifact-bundles/download/test', destination)
+
+    @mock.patch.object(Resource, 'create')
     def test_create_backup_called_once(self, mock_create):
         information = {
             "deploymentGroupURI": "/rest/deployment-groups/00c1344d-e4dd-43c3-a733-1664e159a36f"
         }
+        uri = '/rest/artifact-bundles/backups'
         mock_create.return_value = {}
 
-        self._client.create_backup(information)
-        uri = '/rest/artifact-bundles/backups'
+        self._artifact_bundles.create_backup(information)
         mock_create.assert_called_once_with(information.copy(), uri=uri, timeout=-1)
 
-    @mock.patch.object(ResourceClient, 'upload')
+    @mock.patch.object(ResourceFileHandlerMixin, 'upload')
     def test_upload_artifact_bundle_called_once(self, mock_upload):
-        filepath = "~/HPE-ImageStreamer-Developer-2016-09-12.zip"
+        filepath = "~/upload.zip"
 
-        self._client.upload_bundle_from_file(filepath)
-
+        self._artifact_bundles.upload_bundle_from_file(filepath)
         mock_upload.assert_called_once_with(filepath)
 
-    @mock.patch.object(ResourceClient, 'upload')
+    @mock.patch.object(ResourceFileHandlerMixin, 'upload')
     def test_upload_backup_artifact_bundle_called_once(self, mock_upload):
-        filepath = "~/HPE-ImageStreamer-Developer-2016-09-12.zip"
+        filepath = "~/upload.zip"
         deployment_groups = "/rest/deployment-groups/00c1344d-e4dd-43c3-a733-1664e159a36f"
-
-        self._client.upload_backup_bundle_from_file(filepath, deployment_groups)
-
         expected_uri = '/rest/artifact-bundles/backups/archive?deploymentGrpUri=' + deployment_groups
 
+        self._artifact_bundles.upload_backup_bundle_from_file(filepath, deployment_groups)
         mock_upload.assert_called_once_with(filepath, expected_uri)
 
-    @mock.patch.object(ResourceClient, 'upload')
-    def test_upload_backup_artifact_bundle_called_once_with_id(self, mock_upload):
-        filepath = "~/HPE-ImageStreamer-Developer-2016-09-12.zip"
-        deployment_groups = "00c1344d-e4dd-43c3-a733-1664e159a36f"
-
-        self._client.upload_backup_bundle_from_file(filepath, deployment_groups)
-
-        expected_uri = '/rest/artifact-bundles/backups/archive?' \
-                       'deploymentGrpUri=/rest/deployment-groups/00c1344d-e4dd-43c3-a733-1664e159a36f'
-        mock_upload.assert_called_once_with(filepath, expected_uri)
-
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(ResourceHelper, 'update')
     def test_extract_called_once(self, mock_update):
         mock_update.return_value = {}
+        resource = {}
+        uri = '/rest/artifact-bundles/test?extract=true&forceImport=true'
+        custom_headers = {'Content-Type': 'text/plain;charset=UTF-8'}
 
-        uri = {'uri': '/rest/artifact-bundles/78836581-2b6f-4e26-9969-5667fb5837b4'}
-        custom_headers = {'Content-Type': 'text/plain'}
+        self._artifact_bundles.extract(resource)
+        mock_update.assert_called_once_with(resource, uri, custom_headers=custom_headers, timeout=-1)
 
-        self._client.extract_bundle(uri)
-
-        mock_update.assert_called_once_with(uri, custom_headers=custom_headers, timeout=-1)
-
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(ResourceHelper, 'update')
     def test_extract_backup_bundle_called_once(self, mock_update):
         mock_update.return_value = {}
 
@@ -214,25 +118,23 @@ class ArtifactBundlesTest(TestCase):
             'deploymentGroupURI': '/rest/deployment-groups/00c1344d-e4dd-43c3-a733-1664e159a36f'
         }
 
-        uri = '/rest/artifact-bundles/backups/archive'
+        uri = '/rest/artifact-bundles/backups/test'
 
-        self._client.extract_backup_bundle(data)
+        self._artifact_bundles.extract_backup(data)
+        mock_update.assert_called_once_with(data, uri, timeout=-1)
 
-        mock_update.assert_called_once_with(data, uri=uri, timeout=-1)
-
-    @mock.patch.object(ResourceClient, 'update')
+    @mock.patch.object(ResourceHelper, 'update')
     def test_stop_creation_called_once(self, mock_update):
         mock_update.return_value = {}
 
-        artifact_uri = "/rest/artifact-bundles/04939e89-bcb0-49fc-814f-1a6bc0a2f63c"
         task_uri = "/rest/tasks/A15F9270-46FC-48DF-94A9-D11EDB52877E"
 
-        self._client.stop_artifact_creation(artifact_uri, task_uri)
-
+        artifact_uri = "/rest/artifact-bundles/test"
         uri = artifact_uri + '/stopArtifactCreate'
 
-        task_uri = {
+        data = {
             'taskUri': task_uri
         }
 
-        mock_update.assert_called_once_with(task_uri, uri=uri)
+        self._artifact_bundles.stop_artifact_creation(task_uri, artifact_uri)
+        mock_update.assert_called_once_with(data, uri=uri)

--- a/tests/unit/image_streamer/resources/test_artifact_bundles.py
+++ b/tests/unit/image_streamer/resources/test_artifact_bundles.py
@@ -70,7 +70,7 @@ class ArtifactBundlesTest(TestCase):
         uri = '/rest/artifact-bundles/test'
         destination = '~/image.zip'
 
-        self._artifact_bundles.download(destination, uri)
+        self._artifact_bundles.download(destination)
         mock_download.assert_called_once_with('/rest/artifact-bundles/download/test', destination)
 
     @mock.patch.object(Resource, 'create')
@@ -136,5 +136,5 @@ class ArtifactBundlesTest(TestCase):
             'taskUri': task_uri
         }
 
-        self._artifact_bundles.stop_artifact_creation(task_uri, artifact_uri)
+        self._artifact_bundles.stop_artifact_creation(task_uri)
         mock_update.assert_called_once_with(data, uri=uri)

--- a/tests/unit/image_streamer/test_image_streamer_client.py
+++ b/tests/unit/image_streamer/test_image_streamer_client.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -80,9 +80,9 @@ class ImageStreamerClientTest(TestCase):
     def test_artifact_bundles_has_right_type(self):
         self.assertIsInstance(self._client.artifact_bundles, ArtifactBundles)
 
-    def test_artifact_bundles_lazy_loading(self):
+    def test_artifact_bundles_client(self):
         resource = self._client.artifact_bundles
-        self.assertEqual(resource, self._client.artifact_bundles)
+        self.assertNotEqual(resource, self._client.artifact_bundles)
 
     def test_deployment_groups_has_right_type(self):
         self.assertIsInstance(self._client.deployment_groups, DeploymentGroups)

--- a/tests/unit/resources/test_resource.py
+++ b/tests/unit/resources/test_resource.py
@@ -822,6 +822,14 @@ class ResourceTest(BaseTest):
         result = self.resource_client.delete()
         self.assertTrue(result)
 
+    @mock.patch.object(connection, 'delete')
+    def test_helper_delete_all_should_return_true(self, mock_delete):
+        mock_delete.return_value = None, self.response_body
+
+        filter = "name='Exchange Server'"
+        result = self.resource_helper.delete_all(filter=filter, force=True, timeout=-1)
+        self.assertTrue(result)
+
     @mock.patch.object(Resource, "ensure_resource_data")
     @mock.patch.object(connection, "delete")
     @mock.patch.object(TaskMonitor, "wait_for_task")


### PR DESCRIPTION
### Description
Artifact bundles support fot Api1600

### Issues Resolved
[List any issues this PR will resolve. e.g., Fixes #01]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
