### PR TITLE
Changes for API deprecation below 600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 5.4.0(unreleased)
+#### Notes
+Extends support of the SDK to OneView REST API version 1800 (OneView v5.30).
+
+#### Major changes
+Refactored base class to take default API version as per provided Oneview appliance.
+
 # 5.3.0
 #### Notes
 Extends support of the SDK to OneView REST API version 1800 (OneView v5.30).

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ export ONEVIEWSDK_PROXY='<proxy_host>:<proxy_port>'
 
 The OneView Python SDK supports the API endpoints for HPE OneView 4.10, 4.20, 5.00, 5.20, 5.30.
 
-The current `default` HPE OneView version used by the Python SDK is `4.10`, API `800`.
+The current `default` HPE OneView version used by the Python SDK will pick the version used by OneView appliance provided by customer.
 
 To use a different API, you must set the API version on the OneViewClient configuration, either using the JSON configuration:
 
@@ -254,7 +254,7 @@ OR using the Environment variable:
 export ONEVIEWSDK_API_VERSION='800'
 ```
 
-If this property is not specified, it will fall back to the ```800``` default value.
+If this property is not specified, it will fall back to the default value as per OneView appliance.
 
 The API list is as follows:
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ export ONEVIEWSDK_PROXY='<proxy_host>:<proxy_port>'
 
 The OneView Python SDK supports the API endpoints for HPE OneView 4.10, 4.20, 5.00, 5.20, 5.30.
 
-The current `default` HPE OneView version used by the Python SDK will pick the version used by OneView appliance provided by customer.
+The current `default` HPE OneView version used by the Python SDK will pick the OneView appliance api version.
 
 To use a different API, you must set the API version on the OneViewClient configuration, either using the JSON configuration:
 

--- a/examples/fc_networks.py
+++ b/examples/fc_networks.py
@@ -108,7 +108,7 @@ if scope_name and 300 <= oneview_client.api_version <= 500:
                                          '/scopeUris',
                                          [scope.data['uri']])
         pprint(fc_with_scope)
-    except HPOneViewException, e:
+    except HPOneViewException as e:
         print(e)
 
 # Delete the created network

--- a/hpOneView/connection.py
+++ b/hpOneView/connection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*
 ###
-# (C) Copyright [2019] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2020] Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,15 +48,10 @@ logger = logging.getLogger(__name__)
 
 
 class connection(object):
-    def __init__(self, applianceIp, api_version=800, sslBundle=False, timeout=None):
+    def __init__(self, applianceIp, api_version=None, sslBundle=False, timeout=None):
         self._session = None
         self._host = applianceIp
         self._cred = None
-        self._apiVersion = int(api_version)
-        self._headers = {
-            'X-API-Version': self._apiVersion,
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'}
         self._proxyHost = None
         self._proxyPort = None
         self._doProxy = False
@@ -69,6 +64,20 @@ class connection(object):
         self._numDisplayedRecords = 0
         self._validateVersion = False
         self._timeout = timeout
+        if not api_version:
+            api_version = self.get_default_api_version()
+        self._apiVersion = int(api_version)
+        self._headers = {
+            'X-API-Version': self._apiVersion,
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'}
+
+    def get_default_api_version(self):
+        self._headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'}
+        version = self.get(uri['version'])
+        return version['currentVersion']
 
     def validateVersion(self):
         version = self.get(uri['version'])

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -117,10 +117,9 @@ ONEVIEW_CLIENT_MISSING_IP = 'Oneview ip address is missing'
 
 
 class OneViewClient(object):
-    DEFAULT_API_VERSION = 800
 
     def __init__(self, config):
-        self.__connection = connection(config.get('ip'), config.get('api_version', self.DEFAULT_API_VERSION), config.get('ssl_certificate', False),
+        self.__connection = connection(config.get('ip'), config.get('api_version'), config.get('ssl_certificate', False),
                                        config.get('timeout'))
         self.__image_streamer_ip = config.get("image_streamer_ip")
         self.__validate_host()
@@ -237,7 +236,7 @@ class OneViewClient(object):
         """
         ip = os.environ.get('ONEVIEWSDK_IP', '')
         image_streamer_ip = os.environ.get('ONEVIEWSDK_IMAGE_STREAMER_IP', '')
-        api_version = int(os.environ.get('ONEVIEWSDK_API_VERSION', OneViewClient.DEFAULT_API_VERSION))
+        api_version = os.environ.get('ONEVIEWSDK_API_VERSION')
         ssl_certificate = os.environ.get('ONEVIEWSDK_SSL_CERTIFICATE', '')
         username = os.environ.get('ONEVIEWSDK_USERNAME', '')
         auth_login_domain = os.environ.get('ONEVIEWSDK_AUTH_LOGIN_DOMAIN', '')

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -236,7 +236,7 @@ class OneViewClient(object):
         """
         ip = os.environ.get('ONEVIEWSDK_IP', '')
         image_streamer_ip = os.environ.get('ONEVIEWSDK_IMAGE_STREAMER_IP', '')
-        api_version = os.environ.get('ONEVIEWSDK_API_VERSION')
+        api_version = int(os.environ.get('ONEVIEWSDK_API_VERSION'))
         ssl_certificate = os.environ.get('ONEVIEWSDK_SSL_CERTIFICATE', '')
         username = os.environ.get('ONEVIEWSDK_USERNAME', '')
         auth_login_domain = os.environ.get('ONEVIEWSDK_AUTH_LOGIN_DOMAIN', '')

--- a/hpOneView/oneview_client.py
+++ b/hpOneView/oneview_client.py
@@ -236,7 +236,7 @@ class OneViewClient(object):
         """
         ip = os.environ.get('ONEVIEWSDK_IP', '')
         image_streamer_ip = os.environ.get('ONEVIEWSDK_IMAGE_STREAMER_IP', '')
-        api_version = int(os.environ.get('ONEVIEWSDK_API_VERSION'))
+        api_version = os.environ.get('ONEVIEWSDK_API_VERSION', '')
         ssl_certificate = os.environ.get('ONEVIEWSDK_SSL_CERTIFICATE', '')
         username = os.environ.get('ONEVIEWSDK_USERNAME', '')
         auth_login_domain = os.environ.get('ONEVIEWSDK_AUTH_LOGIN_DOMAIN', '')

--- a/hpOneView/resources/networking/fc_networks.py
+++ b/hpOneView/resources/networking/fc_networks.py
@@ -43,7 +43,7 @@ class FcNetworks(ResourcePatchMixin, Resource):
         '1000': {"type": "fc-networkV4"},
         '1200': {"type": "fc-networkV4"},
         '1600': {"type": "fc-networkV4"},
-        '1800': {"type": "fc-networkv4"}
+        '1800': {"type": "fc-networkV4"}
     }
 
     def __init__(self, connection, data=None):

--- a/tests/unit/image_streamer/resources/test_artifact_bundles.py
+++ b/tests/unit/image_streamer/resources/test_artifact_bundles.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper, ResourceFileH
 class ArtifactBundlesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._artifact_bundles = ArtifactBundles(self.connection)
         self.uri = "/rest/artifact-bundles/test"
         self._artifact_bundles.data = {"uri": self.uri}

--- a/tests/unit/image_streamer/resources/test_build_plans.py
+++ b/tests/unit/image_streamer/resources/test_build_plans.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class BuildPlansTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = BuildPlans(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/image_streamer/resources/test_deployment_groups.py
+++ b/tests/unit/image_streamer/resources/test_deployment_groups.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class DeploymentGroupsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = DeploymentGroups(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/image_streamer/resources/test_deployment_plans.py
+++ b/tests/unit/image_streamer/resources/test_deployment_plans.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceHelper, Resource
 class DeploymentPlansTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = DeploymentPlans(self.connection)
         self.resource_uri = '/rest/deployment-plans/ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._client.data = {'uri': self.resource_uri}

--- a/tests/unit/image_streamer/resources/test_golden_images.py
+++ b/tests/unit/image_streamer/resources/test_golden_images.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class GoldenImagesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = GoldenImages(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/image_streamer/resources/test_os_volumes.py
+++ b/tests/unit/image_streamer/resources/test_os_volumes.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class OsVolumesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = OsVolumes(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/image_streamer/resources/test_plan_scripts.py
+++ b/tests/unit/image_streamer/resources/test_plan_scripts.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class PlanScriptsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = PlanScripts(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/activity/test_alerts.py
+++ b/tests/unit/resources/activity/test_alerts.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class AlertsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = Alerts(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/activity/test_events.py
+++ b/tests/unit/resources/activity/test_events.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class EventsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = Events(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/activity/test_tasks.py
+++ b/tests/unit/resources/activity/test_tasks.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceHelper
 class TasksTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._tasks = Tasks(self.connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/data_services/test_metric_streaming.py
+++ b/tests/unit/resources/data_services/test_metric_streaming.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class MetricStreamingTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._metrics = MetricStreaming(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/facilities/test_datacenters.py
+++ b/tests/unit/resources/facilities/test_datacenters.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class DatacenterTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._datacenters = Datacenters(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/facilities/test_power_devices.py
+++ b/tests/unit/resources/facilities/test_power_devices.py
@@ -27,7 +27,7 @@ from hpOneView.resources.facilities.power_devices import PowerDevices
 class PowerDevicesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._power_devices = PowerDevices(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_utilization')

--- a/tests/unit/resources/facilities/test_racks.py
+++ b/tests/unit/resources/facilities/test_racks.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class RacksTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._racks = Racks(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/fc_sans/test_endpoints.py
+++ b/tests/unit/resources/fc_sans/test_endpoints.py
@@ -29,7 +29,7 @@ TIMEOUT = -1
 class EndpointsTest(TestCase):
     def setUp(self):
         host = '127.0.0.1'
-        http_connection = connection(host)
+        http_connection = connection(host, 800)
         self._resource = Endpoints(http_connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/fc_sans/test_managed_sans.py
+++ b/tests/unit/resources/fc_sans/test_managed_sans.py
@@ -29,7 +29,7 @@ TIMEOUT = -1
 class ManagedSANsTest(TestCase):
     def setUp(self):
         host = '127.0.0.1'
-        http_connection = connection(host)
+        http_connection = connection(host, 800)
         self._resource = ManagedSANs(http_connection)
         self.uri = "/rest/fc-sans/managed-sans/280FF951-F007-478F-AC29-E4655FC76DDC"
         self._resource.data = {"uri": self.uri}

--- a/tests/unit/resources/fc_sans/test_san_managers.py
+++ b/tests/unit/resources/fc_sans/test_san_managers.py
@@ -50,7 +50,7 @@ PROVIDERS = [
 class SanManagersTest(TestCase):
     def setUp(self):
         host = '127.0.0.1'
-        http_connection = connection(host)
+        http_connection = connection(host, 800)
         self._resource = SanManagers(http_connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/hypervisors/test_hypervisor_cluster_profiles.py
+++ b/tests/unit/resources/hypervisors/test_hypervisor_cluster_profiles.py
@@ -28,7 +28,7 @@ class HypervisorClusterProfilesTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._hypervisor_cluster_profiles = HypervisorClusterProfiles(self.connection)
         self.uri = "/rest/hypervisor-cluster-profiles"
         self._hypervisor_cluster_profiles.data = {"uri": self.uri}

--- a/tests/unit/resources/hypervisors/test_hypervisor_managers.py
+++ b/tests/unit/resources/hypervisors/test_hypervisor_managers.py
@@ -28,7 +28,7 @@ class HypervisorManagersTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._hypervisor_managers = HypervisorManagers(self.connection)
         self.uri = "/rest/hypervisor-managers/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
         self._hypervisor_managers.data = {"uri": self.uri}

--- a/tests/unit/resources/networking/test_connection_templates.py
+++ b/tests/unit/resources/networking/test_connection_templates.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper
 class ConnectionTemplatesTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._connection_templates = ConnectionTemplates(self.connection)
 
     @mock.patch.object(ResourceHelper, 'do_requests_to_getall')

--- a/tests/unit/resources/networking/test_ethernet_networks.py
+++ b/tests/unit/resources/networking/test_ethernet_networks.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourcePatchMixin, ResourceH
 class EthernetNetworksTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._ethernet_networks = EthernetNetworks(self.connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/networking/test_fabrics.py
+++ b/tests/unit/resources/networking/test_fabrics.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class FabricsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._fabrics = Fabrics(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/networking/test_fc_networks.py
+++ b/tests/unit/resources/networking/test_fc_networks.py
@@ -28,7 +28,7 @@ class FcNetworksTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._fc_networks = FcNetworks(self.connection)
 
     @mock.patch.object(Resource, 'get_all')

--- a/tests/unit/resources/networking/test_fcoe_networks.py
+++ b/tests/unit/resources/networking/test_fcoe_networks.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper, ResourcePatch
 class FcoeNetworksTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._fcoe_networks = FcoeNetworks(self.connection)
         self.uri = "/rest/fcoe-networks/3518be0e-17c1-4189-8f81-83f3724f6155"
         self._fcoe_networks.data = {"uri": self.uri}

--- a/tests/unit/resources/networking/test_interconnect_link_topologies.py
+++ b/tests/unit/resources/networking/test_interconnect_link_topologies.py
@@ -28,7 +28,7 @@ class InterconnectLinkTopologiesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._interconnect_link_topologies = InterconnectLinkTopologies(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/networking/test_interconnect_types.py
+++ b/tests/unit/resources/networking/test_interconnect_types.py
@@ -28,7 +28,7 @@ class InterconnectTypesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._interconnect_types = InterconnectTypes(self.connection)
 
     @mock.patch.object(ResourceHelper, 'do_requests_to_getall')

--- a/tests/unit/resources/networking/test_interconnects.py
+++ b/tests/unit/resources/networking/test_interconnects.py
@@ -28,7 +28,7 @@ class InterconnectsTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._interconnects = Interconnects(self.connection)
         self._interconnects.data = {'uri': '/rest/interconnects/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
 

--- a/tests/unit/resources/networking/test_internal_link_sets.py
+++ b/tests/unit/resources/networking/test_internal_link_sets.py
@@ -34,7 +34,7 @@ INTERNAL_LINK_SETS = [
 class InternalLinkSetsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = InternalLinkSets(self.connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/networking/test_logical_downlinks.py
+++ b/tests/unit/resources/networking/test_logical_downlinks.py
@@ -28,7 +28,7 @@ class LogicalDownlinksTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._logical_downlinks = LogicalDownlinks(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/networking/test_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_logical_interconnect_groups.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper, ResourcePatch
 class LogicalInterconnectGroupsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._lig = LogicalInterconnectGroups(self.connection)
         self.uri = "/rest/logical-interconnect-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
         self._lig.data = {"uri": self.uri}

--- a/tests/unit/resources/networking/test_logical_interconnects.py
+++ b/tests/unit/resources/networking/test_logical_interconnects.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourcePatchMixin, ResourceHelper
 class LogicalInterconnectsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._logical_interconnect = LogicalInterconnects(self.connection)
         self.uri = '/rest/logical-interconnects/ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._logical_interconnect.data = {

--- a/tests/unit/resources/networking/test_logical_switch_groups.py
+++ b/tests/unit/resources/networking/test_logical_switch_groups.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper, ResourcePatch
 class LogicalSwitchGroupsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._lsg = LogicalSwitchGroups(self.connection)
         self.uri = "/rest/logical-switch-groups/dce3fc90-873e-48f7-8340-cc927d625b16"
         self._lsg.data = {"uri": self.uri}

--- a/tests/unit/resources/networking/test_logical_switches.py
+++ b/tests/unit/resources/networking/test_logical_switches.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class LogicalSwitchesTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._logical_switches = LogicalSwitches(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/networking/test_network_sets.py
+++ b/tests/unit/resources/networking/test_network_sets.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper, ResourcePatch
 class NetworkSetsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._network_sets = NetworkSets(self.connection)
         self._network_sets.data = {'uri': '/rest/network-sets/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
 

--- a/tests/unit/resources/networking/test_sas_interconnect_types.py
+++ b/tests/unit/resources/networking/test_sas_interconnect_types.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceHelper
 class SasInterconnectTypesTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._sas_interconnect_types = SasInterconnectTypes(self.connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/networking/test_sas_logical_interconnect_groups.py
+++ b/tests/unit/resources/networking/test_sas_logical_interconnect_groups.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper
 class SasLogicalInterconnectGroupsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._resource = SasLogicalInterconnectGroups(self.connection)
         self.uri = "/rest/sas-logical-interconnect-groups/3518be0e-17c1-4189-8f81-83f3724f6155"
         self._resource.data = {"uri": self.uri}

--- a/tests/unit/resources/networking/test_sas_logical_interconnects.py
+++ b/tests/unit/resources/networking/test_sas_logical_interconnects.py
@@ -25,7 +25,7 @@ from hpOneView.resources.resource import ResourceHelper
 class SasLogicalInterconnectsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = SasLogicalInterconnects(self.connection)
         self.uri = "/rest/sas-logical-interconnects/ad28cf21-8b15-4f92-bdcf-51cb2042db32"
         self._client.data = {"uri": self.uri}

--- a/tests/unit/resources/networking/test_switch_types.py
+++ b/tests/unit/resources/networking/test_switch_types.py
@@ -28,7 +28,7 @@ class SwitchTypesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._switch_types = SwitchTypes(self.connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/networking/test_switches.py
+++ b/tests/unit/resources/networking/test_switches.py
@@ -28,7 +28,7 @@ class SwitchesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._switches = Switches(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/networking/test_uplink_sets.py
+++ b/tests/unit/resources/networking/test_uplink_sets.py
@@ -28,7 +28,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper
 class UplinkSetsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._uplink_sets = UplinkSets(self.connection)
         self._uplink_sets.data = {'uri': '/rest/ul-inksets/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
         self._ethernet_networks = EthernetNetworks(self.connection)

--- a/tests/unit/resources/search/test_index_resources.py
+++ b/tests/unit/resources/search/test_index_resources.py
@@ -42,7 +42,7 @@ class IndexResourcesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._resource = IndexResources(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all', return_value=dict(members='test'))

--- a/tests/unit/resources/search/test_labels.py
+++ b/tests/unit/resources/search/test_labels.py
@@ -42,7 +42,7 @@ class LabelsTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._resource = Labels(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/security/test_certificate_authority.py
+++ b/tests/unit/resources/security/test_certificate_authority.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class CertificateAuthorityTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._certificates = CertificateAuthority(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/security/test_certificate_rabbitmq.py
+++ b/tests/unit/resources/security/test_certificate_rabbitmq.py
@@ -27,7 +27,7 @@ from hpOneView.resources.security.certificate_rabbitmq import CertificateRabbitM
 class CertificateRabbitMQTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._certificate_rabbitmq = CertificateRabbitMQ(self.connection)
 
     @mock.patch.object(ResourceClient, 'create')

--- a/tests/unit/resources/security/test_certificates_server.py
+++ b/tests/unit/resources/security/test_certificates_server.py
@@ -29,7 +29,7 @@ class CertificatesServerTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._certificate_server = CertificatesServer(self.connection)
         self.uri = "/rest/certificates/servers"
         self._certificate_server.data = {"uri": self.uri}

--- a/tests/unit/resources/security/test_login_details.py
+++ b/tests/unit/resources/security/test_login_details.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class LoginDetailsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._login_details = LoginDetails(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/security/test_roles.py
+++ b/tests/unit/resources/security/test_roles.py
@@ -27,7 +27,7 @@ from hpOneView.resources.security.roles import Roles
 class RolesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = Roles(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/security/test_users.py
+++ b/tests/unit/resources/security/test_users.py
@@ -28,7 +28,7 @@ from hpOneView.exceptions import HPOneViewException
 class UsersTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._users = Users(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/servers/test_connections.py
+++ b/tests/unit/resources/servers/test_connections.py
@@ -28,7 +28,7 @@ class ConnectionsTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._connections = Connections(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/servers/test_enclosure_groups.py
+++ b/tests/unit/resources/servers/test_enclosure_groups.py
@@ -59,7 +59,7 @@ class EnclosureGroupsTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.client = EnclosureGroups(self.connection)
         self.uri = "/rest/enclosure-groups/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
         self.client.data = {"uri": self.uri}

--- a/tests/unit/resources/servers/test_enclosures.py
+++ b/tests/unit/resources/servers/test_enclosures.py
@@ -28,7 +28,7 @@ from hpOneView.resources.resource import (Resource, ResourceHelper, ResourcePatc
 class EnclosuresTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._enclosures = Enclosures(self.connection)
         self._enclosures.data = {'uri': '/rest/enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
 

--- a/tests/unit/resources/servers/test_id_pools.py
+++ b/tests/unit/resources/servers/test_id_pools.py
@@ -29,7 +29,7 @@ class TestIdPools(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.client = IdPools(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/servers/test_id_pools_ipv4_ranges.py
+++ b/tests/unit/resources/servers/test_id_pools_ipv4_ranges.py
@@ -29,7 +29,7 @@ class TestIdPoolsIpv4Ranges(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.client = IdPoolsIpv4Ranges(self.connection)
 
     @mock.patch.object(ResourceClient, 'create')

--- a/tests/unit/resources/servers/test_id_pools_ipv4_subnets.py
+++ b/tests/unit/resources/servers/test_id_pools_ipv4_subnets.py
@@ -27,7 +27,7 @@ class TestIdPoolsIpv4Subnets(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.client = IdPoolsIpv4Subnets(self.connection)
         self.example_uri = "/rest/id-pools/ipv4/subnets/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"
 

--- a/tests/unit/resources/servers/test_id_pools_ranges.py
+++ b/tests/unit/resources/servers/test_id_pools_ranges.py
@@ -29,7 +29,7 @@ class TestIdPoolsRanges(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.id_pool_name = 'vsn'
         self.client = IdPoolsRanges(self.id_pool_name, self.connection)
         self.example_uri = "/rest/id-pools/" + self.id_pool_name + "/ranges/f0a0a113-ec97-41b4-83ce-d7c92b900e7c"

--- a/tests/unit/resources/servers/test_logical_enclosures.py
+++ b/tests/unit/resources/servers/test_logical_enclosures.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper, ResourcePatch
 class LogicalEnclosuresTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._logical_enclosures = LogicalEnclosures(self.connection)
         self.uri = "/rest/logical-enclosures/ad28cf21-8b15-4f92-bdcf-51cb2042db32"
         self._logical_enclosures.data = {"uri": self.uri}

--- a/tests/unit/resources/servers/test_migratable_vc_domains.py
+++ b/tests/unit/resources/servers/test_migratable_vc_domains.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class MigratableVcDomainsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.vcmigrationmanager = MigratableVcDomains(self.connection)
 
     @mock.patch.object(ResourceClient, 'create')

--- a/tests/unit/resources/servers/test_server_hardware.py
+++ b/tests/unit/resources/servers/test_server_hardware.py
@@ -29,7 +29,7 @@ from hpOneView.resources.resource import (ResourceHelper,
 class ServerHardwareTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._server_hardware = ServerHardware(self.connection)
         self.uri = "/rest/server-hardware/1224242424"
         self._server_hardware.data = {"uri": self.uri}

--- a/tests/unit/resources/servers/test_server_hardware_types.py
+++ b/tests/unit/resources/servers/test_server_hardware_types.py
@@ -26,7 +26,7 @@ class ServerHardwareTypesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._server_hardware_types = ServerHardwareTypes(self.connection)
         self.uri = "/rest/server-hardware-types/ad28cf21-8b15-4f92-bdcf-51cb2042db32"
         self._server_hardware_types.data = {'uri': self.uri}

--- a/tests/unit/resources/servers/test_server_profile_templates.py
+++ b/tests/unit/resources/servers/test_server_profile_templates.py
@@ -30,7 +30,7 @@ class ServerProfileTemplateTest(TestCase):
 
     def setUp(self):
         host = '127.0.0.1'
-        http_connection = connection(host)
+        http_connection = connection(host, 800)
         self._resource = ServerProfileTemplate(http_connection)
         self.uri = "/rest/server-profile-templates/test"
         self._resource.data = {"uri": self.uri}

--- a/tests/unit/resources/servers/test_server_profiles.py
+++ b/tests/unit/resources/servers/test_server_profiles.py
@@ -30,7 +30,7 @@ TIMEOUT = -1
 class ServerProfilesTest(TestCase):
     def setUp(self):
         host = '127.0.0.1'
-        http_connection = connection(host)
+        http_connection = connection(host, 800)
         self._resource = ServerProfiles(http_connection)
         self.uri = "/rest/server-profiles/4ff2327f-7638-4b66-ad9d-283d4940a4ae"
         self._resource.data = {"uri": self.uri}

--- a/tests/unit/resources/settings/test_appliance_device_read_community.py
+++ b/tests/unit/resources/settings/test_appliance_device_read_community.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class ApplianceDeviceReadCommunityTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._read_community = ApplianceDeviceReadCommunity(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/settings/test_appliance_device_snmp_v1_trap_destinations.py
+++ b/tests/unit/resources/settings/test_appliance_device_snmp_v1_trap_destinations.py
@@ -28,7 +28,7 @@ class ApplianceDeviceSNMPv1TrapDestinationsTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.__appliance_device_snmp_v1_trap_destinations = ApplianceDeviceSNMPv1TrapDestinations(self.connection)
         self.uri = "/rest/appliance/trap-destinations"
         self.__appliance_device_snmp_v1_trap_destinations.data = {"uri": self.uri}

--- a/tests/unit/resources/settings/test_appliance_device_snmp_v3_trap_destinations.py
+++ b/tests/unit/resources/settings/test_appliance_device_snmp_v3_trap_destinations.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class ApplianceDeviceSNMPv3TrapDestinationsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._snmp_v3_trap_dest = ApplianceDeviceSNMPv3TrapDestinations(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/settings/test_appliance_device_snmp_v3_users.py
+++ b/tests/unit/resources/settings/test_appliance_device_snmp_v3_users.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class ApplianceDeviceSNMPv3UsersTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._snmp_v3_users = ApplianceDeviceSNMPv3Users(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/settings/test_appliance_node_information.py
+++ b/tests/unit/resources/settings/test_appliance_node_information.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class ApplianceTimeAndLocaleConfigurationTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._node_information = ApplianceNodeInformation(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/settings/test_appliance_time_and_locale_configuration.py
+++ b/tests/unit/resources/settings/test_appliance_time_and_locale_configuration.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class ApplianceTimeAndLocaleConfigurationTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._time_and_locale = ApplianceTimeAndLocaleConfiguration(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/settings/test_backups.py
+++ b/tests/unit/resources/settings/test_backups.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class BackupsTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = Backups(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_collection')

--- a/tests/unit/resources/settings/test_firmware_bundles.py
+++ b/tests/unit/resources/settings/test_firmware_bundles.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class FirmwareBundlesTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._firmware_bundles = FirmwareBundles(self.connection)
 
     @mock.patch.object(ResourceClient, 'upload')

--- a/tests/unit/resources/settings/test_firmware_drivers.py
+++ b/tests/unit/resources/settings/test_firmware_drivers.py
@@ -28,7 +28,7 @@ class FirmwareDriversTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._firmware_drivers = FirmwareDrivers(self.connection)
         self.uri = "/rest/firmware-drivers"
         self._firmware_drivers.data = {"uri": self.uri}

--- a/tests/unit/resources/settings/test_licenses.py
+++ b/tests/unit/resources/settings/test_licenses.py
@@ -28,7 +28,7 @@ class LicensesTest(TestCase):
     DEFAULT_HOST = '127.0.0.1'
 
     def setUp(self):
-        oneview_connection = connection(self.DEFAULT_HOST)
+        oneview_connection = connection(self.DEFAULT_HOST, 800)
         self.resource = Licenses(oneview_connection)
 
     @mock.patch.object(ResourceClient, 'create')

--- a/tests/unit/resources/settings/test_restores.py
+++ b/tests/unit/resources/settings/test_restores.py
@@ -27,7 +27,7 @@ from hpOneView.resources.settings.restores import Restores
 class RestoresTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.resource = Restores(self.connection)
 
     @mock.patch.object(ResourceHelper, 'do_get')

--- a/tests/unit/resources/settings/test_scopes.py
+++ b/tests/unit/resources/settings/test_scopes.py
@@ -28,7 +28,7 @@ class ScopesTest(TestCase):
     DEFAULT_HOST = '127.0.0.1'
 
     def setUp(self):
-        oneview_connection = connection(self.DEFAULT_HOST)
+        oneview_connection = connection(self.DEFAULT_HOST, 800)
         self.resource = Scopes(oneview_connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/settings/test_versions.py
+++ b/tests/unit/resources/settings/test_versions.py
@@ -25,7 +25,7 @@ from hpOneView.resources.resource import ResourceClient
 class VersionsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._client = Versions(self.connection)
 
     @mock.patch.object(ResourceClient, 'get')

--- a/tests/unit/resources/storage/test_drive_enclosures.py
+++ b/tests/unit/resources/storage/test_drive_enclosures.py
@@ -31,7 +31,7 @@ class DriveEnclosuresTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._drive_enclosures = DriveEnclosures(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/storage/test_sas_logical_jbod_attachments.py
+++ b/tests/unit/resources/storage/test_sas_logical_jbod_attachments.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceClient
 class SasLogicalJbodAttachmentsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._sas_logical_jbod_attachments = SasLogicalJbodAttachments(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/storage/test_sas_logical_jbods.py
+++ b/tests/unit/resources/storage/test_sas_logical_jbods.py
@@ -31,7 +31,7 @@ class SasLogicalJbodsTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._resource = SasLogicalJbods(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/storage/test_storage_pools.py
+++ b/tests/unit/resources/storage/test_storage_pools.py
@@ -28,7 +28,7 @@ class StoragePoolsTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._storage_pools = StoragePools(self.connection)
         self.uri = '/rest/storage-pools/ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._storage_pools.data = {'uri': self.uri}

--- a/tests/unit/resources/storage/test_storage_systems.py
+++ b/tests/unit/resources/storage/test_storage_systems.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import Resource, ResourceHelper
 class StorageSystemsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._storage_systems = StorageSystems(self.connection)
         self._storage_systems.data = {'uri': '/rest/storage-systems/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
 

--- a/tests/unit/resources/storage/test_storage_volume_attachments.py
+++ b/tests/unit/resources/storage/test_storage_volume_attachments.py
@@ -27,7 +27,7 @@ from hpOneView.resources.resource import ResourceHelper, Resource
 class StorageVolumeAttachmentsTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._storage_volume_attachments = StorageVolumeAttachments(self.connection)
         self.uri = '/rest/storage-volume-attachments/ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._storage_volume_attachments.data = {'uri': self.uri}

--- a/tests/unit/resources/storage/test_storage_volume_templates.py
+++ b/tests/unit/resources/storage/test_storage_volume_templates.py
@@ -28,7 +28,7 @@ class StorageVolumeTemplatesTest(unittest.TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._storage_volume_templates = StorageVolumeTemplates(self.connection)
         self._storage_volume_templates.data = {'uri': '/rest/storage-volume-templates/ad28cf21-8b15-4f92-bdcf-51cb2042db32'}
 

--- a/tests/unit/resources/storage/test_volumes.py
+++ b/tests/unit/resources/storage/test_volumes.py
@@ -27,7 +27,7 @@ from hpOneView.resources.storage.volumes import Volumes
 class VolumesTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._volumes = Volumes(self.connection)
         self.resource_uri = '/rest/storage-volumes/ad28cf21-8b15-4f92-bdcf-51cb2042db32'
         self._volumes.data = {'uri': self.resource_uri}

--- a/tests/unit/resources/test_task_monitor.py
+++ b/tests/unit/resources/test_task_monitor.py
@@ -31,7 +31,7 @@ class TaskMonitorTest(unittest.TestCase):
     def setUp(self):
         super(TaskMonitorTest, self).setUp()
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.task_monitor = TaskMonitor(self.connection)
 
     @mock.patch.object(connection, 'get')

--- a/tests/unit/resources/uncategorized/test_os_deployment_plans.py
+++ b/tests/unit/resources/uncategorized/test_os_deployment_plans.py
@@ -30,7 +30,7 @@ class OsDeploymentPlansTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._os_deployment_plans = OsDeploymentPlans(self.connection)
 
     @mock.patch.object(ResourceHelper, 'get_all')

--- a/tests/unit/resources/uncategorized/test_os_deployment_servers.py
+++ b/tests/unit/resources/uncategorized/test_os_deployment_servers.py
@@ -30,7 +30,7 @@ class OsDeploymentServersTest(TestCase):
 
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._os_deployment_servers = OsDeploymentServers(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/resources/uncategorized/test_unmanaged_devices.py
+++ b/tests/unit/resources/uncategorized/test_unmanaged_devices.py
@@ -27,7 +27,7 @@ from hpOneView.resources.uncategorized.unmanaged_devices import UnmanagedDevices
 class UnmanagedDevicesTest(TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self._unmanaged_devices = UnmanagedDevices(self.connection)
 
     @mock.patch.object(ResourceClient, 'get_all')

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -119,8 +119,8 @@ class ConnectionTest(unittest.TestCase):
     def test_headers_with_default_api_version_800(self, mock_get):
         self.connection._apiVersion = None
         mock_get.side_effect = [{'minimumVersion': 400, 'currentVersion': 1800}]
-        expected_version = self.connection.get_default_api_version()
-        self.assertEqual(expected_version, 1800)
+        expected_version = self.connection.get_default_api_version()
+        self.assertEqual(expected_version, 1800)
 
     @patch.object(HTTPSConnection, 'request')
     @patch.object(HTTPSConnection, 'getresponse')

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -31,7 +31,7 @@ from hpOneView.exceptions import HPOneViewException
 class ConnectionTest(unittest.TestCase):
     def setUp(self):
         self.host = '127.0.0.1'
-        self.connection = connection(self.host)
+        self.connection = connection(self.host, 800)
         self.accept_language_header = {
             'Accept-Language': 'en_US'
         }

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -109,9 +109,16 @@ class ConnectionTest(unittest.TestCase):
         self.connection.disable_etag_validation()
         self.assertEqual(self.default_headers_with_etag_validation_off, self.connection._headers)
 
-    def test_headers_with_api_version_800(self):
-        self.connection = connection(self.host, 800)
+    @patch.object(connection, 'get')
+    def test_headers_with_api_version_800(self, mock_get):
+        self.connection._apiVersion = None
+        mock_get.side_effect = [{'minimumVersion': 400, 'currentVersion': 1800}]
+        expected_version = self.default_headers.copy()
+        self.assertEqual(expected_headers, 1800)
 
+    def test_headers_with_default_api_version_800(self):
+        self.connection = connection(self.host)
+        self.connection.get_default_api_version()
         expected_headers = self.default_headers.copy()
         expected_headers['X-API-Version'] = 800
         self.assertEqual(expected_headers, self.connection._headers)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -117,6 +117,7 @@ class ConnectionTest(unittest.TestCase):
 
     @patch.object(connection, 'get')
     def test_headers_with_default_api_version_800(self, mock_get):
+        self.connection = connection(self.host)
         self.connection._apiVersion = None
         mock_get.side_effect = [{'minimumVersion': 400, 'currentVersion': 1800}]
         expected_version = self.connection.get_default_api_version()

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -109,19 +109,18 @@ class ConnectionTest(unittest.TestCase):
         self.connection.disable_etag_validation()
         self.assertEqual(self.default_headers_with_etag_validation_off, self.connection._headers)
 
-    @patch.object(connection, 'get')
-    def test_headers_with_api_version_800(self, mock_get):
-        self.connection._apiVersion = None
-        mock_get.side_effect = [{'minimumVersion': 400, 'currentVersion': 1800}]
-        expected_version = self.default_headers.copy()
-        self.assertEqual(expected_headers, 1800)
-
-    def test_headers_with_default_api_version_800(self):
-        self.connection = connection(self.host)
-        self.connection.get_default_api_version()
+    def test_headers_with_api_version_800(self):
+        self.connection = connection(self.host, 800)
         expected_headers = self.default_headers.copy()
         expected_headers['X-API-Version'] = 800
         self.assertEqual(expected_headers, self.connection._headers)
+
+    @patch.object(connection, 'get')
+    def test_headers_with_default_api_version_800(self, mock_get):
+        self.connection._apiVersion = None
+        mock_get.side_effect = [{'minimumVersion': 400, 'currentVersion': 1800}]
+        expected_version = self.connection.get_default_api_version()
+        self.assertEqual(expected_version, 1800)
 
     @patch.object(HTTPSConnection, 'request')
     @patch.object(HTTPSConnection, 'getresponse')

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -265,7 +265,6 @@ class OneViewClientTest(unittest.TestCase):
 
         mock_login.assert_called_once_with(dict(userName='admin',
                                                 password='secret123',
-                                                api_version='800',
                                                 authLoginDomain='',
                                                 sessionID=''))
         mock_set_proxy.assert_not_called()
@@ -280,7 +279,6 @@ class OneViewClientTest(unittest.TestCase):
         mock_login.assert_called_once_with(dict(userName='',
                                                 password='',
                                                 authLoginDomain='',
-                                                api_version='800',
                                                 sessionID='123'))
         mock_set_proxy.assert_not_called()
         self.assertEqual(800, oneview_client.connection._apiVersion)
@@ -356,7 +354,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_only_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 800,
+        mock_cls.assert_called_once_with({'api_version': '800',
                                           'proxy': '',
                                           'timeout': None,
                                           'ip': '172.16.100.199',

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -129,6 +129,7 @@ class OneViewClientTest(unittest.TestCase):
         super(OneViewClientTest, self).setUp()
 
         config = {"ip": "172.16.102.59",
+                  "api_version": 800,
                   "proxy": "127.0.0.1:3128",
                   "credentials": {
                       "authLoginDomain": "",
@@ -139,6 +140,7 @@ class OneViewClientTest(unittest.TestCase):
 
     def test_raise_error_missing_ip(self):
         config = {"ip": "",
+                  "api_version": 800,
                   "credentials": {
                       "userName": "administrator",
                       "password": ""}}
@@ -150,6 +152,7 @@ class OneViewClientTest(unittest.TestCase):
 
     def test_raise_error_invalid_proxy(self):
         config = {"ip": "172.16.102.59",
+                  "api_version": 800,
                   "proxy": "3128",
                   "credentials": {
                       "authLoginDomain": "",
@@ -168,6 +171,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_json_file(self, mock_open, mock_login):
         json_config_content = u"""{
           "ip": "172.16.102.59",
+          "api_version": 800,
           "credentials": {
             "userName": "administrator",
             "authLoginDomain": "",
@@ -185,6 +189,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_json_file_with_sessionID(self, mock_open, mock_login):
         json_config_content = u"""{
           "ip": "172.16.102.59",
+          "api_version": 800,
           "credentials": {
             "userName": "administrator",
             "authLoginDomain": "",
@@ -203,6 +208,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_json_file_with_only_sessionID(self, mock_open, mock_login):
         json_config_content = u"""{
           "ip": "172.16.102.59",
+          "api_version": 800,
           "credentials": {
             "sessionID": "123"
           }
@@ -218,6 +224,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_default_api_version(self, mock_open, mock_login):
         json_config_content = u"""{
           "ip": "172.16.102.59",
+          "api_version": 800,
           "credentials": {
             "userName": "administrator",
             "authLoginDomain": "",
@@ -361,6 +368,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_create_image_streamer_client_without_image_streamer_ip(self, mock_login):
 
         config = {"ip": "172.16.102.59",
+                  "api_version": 800,
                   "credentials": {
                       "userName": "administrator",
                       "password": "password"}}
@@ -378,6 +386,7 @@ class OneViewClientTest(unittest.TestCase):
 
         config = {"ip": "172.16.102.59",
                   "image_streamer_ip": "172.16.102.50",
+                  "api_version": 800,
                   "credentials": {
                       "userName": "administrator",
                       "password": "password"}}

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -320,7 +320,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': '201',
+        mock_cls.assert_called_once_with({'api_version': 201,
                                           'proxy': '172.16.100.195:9999',
                                           'timeout': '20',
                                           'ip': '172.16.100.199',
@@ -337,7 +337,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': '201',
+        mock_cls.assert_called_once_with({'api_version': 201,
                                           'proxy': '172.16.100.195:9999',
                                           'timeout': '20',
                                           'ip': '172.16.100.199',
@@ -354,7 +354,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_only_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': '800',
+        mock_cls.assert_called_once_with({'api_version': 800,
                                           'proxy': '',
                                           'timeout': None,
                                           'ip': '172.16.100.199',

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -320,7 +320,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 201,
+        mock_cls.assert_called_once_with({'api_version': '201',
                                           'proxy': '172.16.100.195:9999',
                                           'timeout': '20',
                                           'ip': '172.16.100.199',
@@ -337,7 +337,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 201,
+        mock_cls.assert_called_once_with({'api_version': '201',
                                           'proxy': '172.16.100.195:9999',
                                           'timeout': '20',
                                           'ip': '172.16.100.199',
@@ -354,7 +354,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_only_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 800,
+        mock_cls.assert_called_once_with({'api_version': '800',
                                           'proxy': '',
                                           'timeout': None,
                                           'ip': '172.16.100.199',

--- a/tests/unit/test_oneview_client.py
+++ b/tests/unit/test_oneview_client.py
@@ -87,12 +87,14 @@ from hpOneView.resources.hypervisors.hypervisor_cluster_profiles import Hypervis
 OS_ENVIRON_CONFIG_MINIMAL = {
     'ONEVIEWSDK_IP': '172.16.100.199',
     'ONEVIEWSDK_USERNAME': 'admin',
-    'ONEVIEWSDK_PASSWORD': 'secret123'
+    'ONEVIEWSDK_PASSWORD': 'secret123',
+    'ONEVIEWSDK_API_VERSION': '800'
 }
 
 OS_ENVIRON_CONFIG_MINIMAL_WITH_SESSIONID = {
     'ONEVIEWSDK_IP': '172.16.100.199',
-    'ONEVIEWSDK_SESSIONID': '123'
+    'ONEVIEWSDK_SESSIONID': '123',
+    'ONEVIEWSDK_API_VERSION': '800'
 }
 
 OS_ENVIRON_CONFIG_FULL = {
@@ -263,6 +265,7 @@ class OneViewClientTest(unittest.TestCase):
 
         mock_login.assert_called_once_with(dict(userName='admin',
                                                 password='secret123',
+                                                api_version='800',
                                                 authLoginDomain='',
                                                 sessionID=''))
         mock_set_proxy.assert_not_called()
@@ -277,6 +280,7 @@ class OneViewClientTest(unittest.TestCase):
         mock_login.assert_called_once_with(dict(userName='',
                                                 password='',
                                                 authLoginDomain='',
+                                                api_version='800',
                                                 sessionID='123'))
         mock_set_proxy.assert_not_called()
         self.assertEqual(800, oneview_client.connection._apiVersion)
@@ -318,7 +322,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 201,
+        mock_cls.assert_called_once_with({'api_version': '201',
                                           'proxy': '172.16.100.195:9999',
                                           'timeout': '20',
                                           'ip': '172.16.100.199',
@@ -335,7 +339,7 @@ class OneViewClientTest(unittest.TestCase):
     def test_from_environment_variables_is_passing_right_arguments_to_the_constructor_with_sessionID(self, mock_cls):
         mock_cls.return_value = None
         OneViewClient.from_environment_variables()
-        mock_cls.assert_called_once_with({'api_version': 201,
+        mock_cls.assert_called_once_with({'api_version': '201',
                                           'proxy': '172.16.100.195:9999',
                                           'timeout': '20',
                                           'ip': '172.16.100.199',


### PR DESCRIPTION
### Description
Changes for API deprecation below 600

### Issues Resolved
NA

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass for Python 2.7+ & 3.4+(`$ tox`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in the examples (please include helpful comments).
  - [x] New endpoints supported are updated in the endpoints-support.md file.
- [x] Changes are documented in the CHANGELOG.
